### PR TITLE
Support node v14.15.1

### DIFF
--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -47,6 +47,7 @@
         "NOT_EXIST_PATH" : "The specified path does not exist",
         "NOT_EXIST_SSHKEY_PASSWD" : "Private key file or password does not exist",
         "NOT_EXIST_DISPLAY" : "No existing displayId from getSessionList",
+        "NOT_EXIST_REQUESTHANDLER" : "The request handler does not exist",
         "NOT_SUPPORT_ENYO" : "Enyo app packaging is not supported",
         "NOT_SUPPORT_AUTHTYPE" : "Not supported auth type",
         "NOT_SUPPORT_RUNNINGLIST" : "Not supported method to get running app information",

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -36,16 +36,18 @@ const fs = require('fs'),
         app.use("/", Express.static(appPath));
         app.use("/ares_cli", Express.static(__dirname));
         app.use(bodyParser.json());
-        app.configure(function() {
-            if (reqHandlerForIFrame) {
-                app.post('/ares_cli/@@ARES_CLOSE@@', function(req, res) {
-                    reqHandlerForIFrame("@@ARES_CLOSE@@", res);
-                });
-                app.post('/ares_cli/@@GET_URL@@', function(req, res) {
-                    reqHandlerForIFrame("@@GET_URL@@", res);
-                });
-            }
-        });
+
+        if (reqHandlerForIFrame) {
+            app.post('/ares_cli/@@ARES_CLOSE@@', function(req, res) {
+                reqHandlerForIFrame("@@ARES_CLOSE@@", res);
+            });
+            app.post('/ares_cli/@@GET_URL@@', function(req, res) {
+                reqHandlerForIFrame("@@GET_URL@@", res);
+            });
+        } else {
+            return next(new Error("request handler is not exist"));
+        }
+
         const localServer = http.createServer(app);
         localServer.listen(port, function(err) {
             if (err) {

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -8,7 +8,8 @@ const fs = require('fs'),
     Express = require('express'),
     http = require('http'),
     bodyParser = require('body-parser'),
-    spawn = require('child_process').spawn;
+    spawn = require('child_process').spawn,
+    errHndl = require('./error-handler');
 
 (function () {
     const platformOpen = {
@@ -45,7 +46,7 @@ const fs = require('fs'),
                 reqHandlerForIFrame("@@GET_URL@@", res);
             });
         } else {
-            return next(new Error("request handler is not exist"));
+            return next(errHndl.changeErrMsg("NOT_EXIST_REQUESTHANDLER"));
         }
 
         const localServer = http.createServer(app);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -87,6 +87,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
     },
     "acorn": {
       "version": "7.4.1",
@@ -177,6 +186,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
       "version": "3.1.1",
@@ -399,11 +413,6 @@
         }
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w="
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -559,14 +568,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-1.2.0.tgz",
-      "integrity": "sha1-/VcTv6FTx9bMWZN4patMRcU1Ap4=",
-      "requires": {
-        "keypress": "0.1.x"
-      }
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -596,37 +597,6 @@
         }
       }
     },
-    "connect": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-2.8.8.tgz",
-      "integrity": "sha1-uav4yvC9l3PLPeopNEEZhyWCRG0=",
-      "requires": {
-        "buffer-crc32": "0.2.1",
-        "bytes": "0.2.0",
-        "cookie": "0.1.0",
-        "cookie-signature": "1.0.1",
-        "debug": "*",
-        "formidable": "1.0.14",
-        "fresh": "0.2.0",
-        "methods": "0.0.1",
-        "pause": "0.0.1",
-        "qs": "0.6.5",
-        "send": "0.1.4",
-        "uid2": "0.0.2"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz",
-          "integrity": "sha1-qtM+wU49wsp06OfUUfm6BTrU96A="
-        },
-        "qs": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
-          "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8="
-        }
-      }
-    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -638,20 +608,28 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
-      "integrity": "sha1-ROByFIrwHm6OJK+/EmkNaK5pjss="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -787,6 +765,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -838,6 +821,11 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "encoding": {
       "version": "0.1.13",
@@ -900,6 +888,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1159,6 +1152,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -1195,28 +1193,40 @@
       }
     },
     "express": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/express/-/express-3.3.8.tgz",
-      "integrity": "sha1-jpisMNgfTJW4XXHSr2z4T2LvGb0=",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
       "requires": {
-        "buffer-crc32": "0.2.1",
-        "commander": "1.2.0",
-        "connect": "2.8.8",
-        "cookie": "0.1.0",
-        "cookie-signature": "1.0.1",
-        "debug": "*",
-        "fresh": "0.2.0",
-        "methods": "0.0.1",
-        "mkdirp": "0.3.5",
-        "range-parser": "0.0.4",
-        "send": "0.1.4"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-        }
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
       }
     },
     "extend": {
@@ -1444,6 +1454,20 @@
         }
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -1507,10 +1531,10 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formidable": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-      "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -1522,9 +1546,9 @@
       }
     },
     "fresh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
-      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -1918,6 +1942,11 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -2238,11 +2267,6 @@
         "verror": "1.10.0"
       }
     },
-    "keypress": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2314,6 +2338,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2321,9 +2350,9 @@
       "dev": true
     },
     "methods": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
-      "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -2347,9 +2376,9 @@
       }
     },
     "mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -2445,6 +2474,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -2676,6 +2710,11 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -2710,6 +2749,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -2718,11 +2762,6 @@
       "requires": {
         "pify": "^2.0.0"
       }
-    },
-    "pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pend": {
       "version": "1.2.0",
@@ -2772,6 +2811,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -2788,9 +2836,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "range-parser": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
-      "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.0",
@@ -2997,14 +3045,41 @@
       "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "send": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
-      "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "requires": {
-        "debug": "*",
-        "fresh": "0.2.0",
-        "mime": "~1.2.9",
-        "range-parser": "0.0.4"
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "set-blocking": {
@@ -3735,11 +3810,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "uid2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.2.tgz",
-      "integrity": "sha1-EH+xVcgsETZiB5ftTIjPKwj2qrg="
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -3827,6 +3897,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -3847,6 +3922,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Command Line Interface for development webOS application and service",
   "main": "./bin/ares.js",
   "author": "ye.kim",
@@ -43,7 +43,7 @@
     "easy-table": "1.1.1",
     "elfy": "1.0.0",
     "encoding": "0.1.13",
-    "express": "3.3.8",
+    "express": "4.17.1",
     "extract-zip": "1.7.0",
     "fs-extra": "8.1.0",
     "fstream": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Command Line Interface for development webOS application and service",
   "main": "./bin/ares.js",
   "author": "ye.kim",


### PR DESCRIPTION
:Release Notes:
Support node v14.15.1

:Detailed Notes:
As upgrade node version to v14.15.1, deprecated API occurs.
Accordingly fix the API and update lib/base/server.js.

:Testing Performed:
1. Before CLI test, change settings
  - Upgrade node version to v14.15.1
  - Remove node_modules
  - Re-install npm as 'npm install'
2. Check below commands
  - ares-server and click or open returned url
  - ares-inspec and --open option
  - ares-launch -H option
3. Pass unit test on ose and auto
4. Pass eslint

:Issues Addressed:
[PLAT-128958] Support node v14.15.1