### PR TITLE
Support ares-generate on node v14.15.1

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -232,7 +232,7 @@ Generator.prototype.generate = function(options) {
                     let qmlFile = fs.readFileSync(file, 'utf8');
                     qmlFile = qmlFile.replace(exp, "appId: \"" + appId + "\"");
 
-                    fs.writeFileAsync(destFile, qmlFile, {encoding: 'utf8'});
+                    fs.writeFileSync(destFile, qmlFile, {encoding: 'utf8'});
                 });
         }))
         .then( function() {
@@ -260,7 +260,7 @@ Generator.prototype.generate = function(options) {
                     html=html.replace(exp, "\'"+url+"\'");
                     const destFile = path.join(dest, path.basename(file));
 
-                    fs.writeFileAsync(destFile, html, {encoding: 'utf8'});
+                    fs.writeFileSync(destFile, html, {encoding: 'utf8'});
                 });
         }))
         .then( function() {
@@ -305,7 +305,7 @@ Generator.prototype.generate = function(options) {
                     const destFile = path.join(dest, path.basename(file));
                     return fs.mkdirsAsync(dest)
                         .then(function() {
-                            return fs.writeFileAsync(destFile, JSON.stringify(info, null, 2), {
+                            return fs.writeFileSync(destFile, JSON.stringify(info, null, 2), {
                                 encoding: 'utf8'
                             });
                         });


### PR DESCRIPTION
:Release Notes:
Support ares-generate on node v14.15.1

:Detailed Notes:
As upgrade node version to v14.15.1, sometimes timing issue occurs
on ares-generate. Accordingly update and fix lib/generator.js.

:Testing Performed:
1. Before CLI test, change settings
  - Upgrade node version to v14.15.1
  - Remove node_modules
  - Re-install npm as 'npm install'
2. Check below commands and test each command at least 3 times

2-1. generate hosted_webapp
    - ares-generate.js -t hosted_webapp webapp -p "url=www.google.com"
    - cat webapp/index.html
    - check "www.google.com" exist in source code

2-2. generate qmlapp
    - ares-generate.js -t qmlapp qmlapp -p "id=com.test.app"
    - cat qmlapp/main.qml
    - check appId: "com.test.app" exist in source code
   
3. Pass unit test on ose and auto
4. Pass eslint

:Issues Addressed:
[PLAT-129646] Support ares-generate on node v14.15.1