### PR TITLE
Fix ares-launch --hosted bug

### DIFF
--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -47,7 +47,6 @@
         "NOT_EXIST_PATH" : "The specified path does not exist",
         "NOT_EXIST_SSHKEY_PASSWD" : "Private key file or password does not exist",
         "NOT_EXIST_DISPLAY" : "No existing displayId from getSessionList",
-        "NOT_EXIST_REQUESTHANDLER" : "The request handler does not exist",
         "NOT_SUPPORT_ENYO" : "Enyo app packaging is not supported",
         "NOT_SUPPORT_AUTHTYPE" : "Not supported auth type",
         "NOT_SUPPORT_RUNNINGLIST" : "Not supported method to get running app information",

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -8,8 +8,7 @@ const fs = require('fs'),
     Express = require('express'),
     http = require('http'),
     bodyParser = require('body-parser'),
-    spawn = require('child_process').spawn,
-    errHndl = require('./error-handler');
+    spawn = require('child_process').spawn;
 
 (function () {
     const platformOpen = {

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -45,8 +45,6 @@ const fs = require('fs'),
             app.post('/ares_cli/@@GET_URL@@', function(req, res) {
                 reqHandlerForIFrame("@@GET_URL@@", res);
             });
-        } else {
-            return next(errHndl.changeErrMsg("NOT_EXIST_REQUESTHANDLER"));
         }
 
         const localServer = http.createServer(app);


### PR DESCRIPTION
:Release Notes:
Remove error text in run server function

:Detailed Notes:
When requestHandler is null when web server runs,
the operation is finished due to error showing.
- Remove requestHandler error print

:Testing Performed:
- Unit test passed on OSE/Auto target
- ESLint done
- Run CLI command on Auto target
  $ ares-generate -t webapp sampleWebApp
  $ ares-launch --hosted sampleWebApp --display 1

:Issues Addressed:
[PLAT-129808] [SDK_CLI] Unable to launch "sampleWebApp" on display 1