### PR TITLE
Update deprecated Buffer on node v14.15.1

### DIFF
--- a/lib/base/novacom.js
+++ b/lib/base/novacom.js
@@ -180,7 +180,6 @@ const fs = require('fs'),
         _loadOne: function(inDevice, next) {
             log.silly("Resolver#_loadOne()", "device:", inDevice);
             if (typeof inDevice.privateKey === 'string') {
-                console.log("novacom__")
                 inDevice.privateKeyName = inDevice.privateKey;
                 inDevice.privateKey = Buffer.from(inDevice.privateKey, 'base64');
                 setImmediate(next);

--- a/lib/base/novacom.js
+++ b/lib/base/novacom.js
@@ -180,8 +180,9 @@ const fs = require('fs'),
         _loadOne: function(inDevice, next) {
             log.silly("Resolver#_loadOne()", "device:", inDevice);
             if (typeof inDevice.privateKey === 'string') {
+                console.log("novacom__")
                 inDevice.privateKeyName = inDevice.privateKey;
-                inDevice.privateKey = new Buffer(inDevice.privateKey, 'base64');
+                inDevice.privateKey = Buffer.from(inDevice.privateKey, 'base64');
                 setImmediate(next);
             } else if (typeof inDevice.privateKey === 'object' && typeof inDevice.privateKey.openSsh === 'string') {
                 inDevice.privateKeyName = inDevice.privateKey.openSsh;

--- a/lib/install.js
+++ b/lib/install.js
@@ -105,9 +105,8 @@ const fs = require('fs'),
                     next();
                 },
                 function(next) {
-                    console.log("install__")
                     const md5 = crypto.createHash('md5'),
-                        buffer=Buffer.alloc(md5DataSize);////
+                        buffer = Buffer.alloc(md5DataSize);
                     let pos = 0;
 
                     async.waterfall([

--- a/lib/install.js
+++ b/lib/install.js
@@ -105,8 +105,9 @@ const fs = require('fs'),
                     next();
                 },
                 function(next) {
+                    console.log("install__")
                     const md5 = crypto.createHash('md5'),
-                        buffer=new Buffer(md5DataSize);
+                        buffer=Buffer.alloc(md5DataSize);////
                     let pos = 0;
 
                     async.waterfall([

--- a/lib/package.js
+++ b/lib/package.js
@@ -633,7 +633,6 @@ const async = require('async'),
 
     function checkELFHeader(next) {
         log.verbose("checkELFHeader");
-        console.log("checkELFHeader__")
         const self = this,
             ELF_HEADER_LEN = 64,
             buf = Buffer.alloc(ELF_HEADER_LEN),
@@ -1107,7 +1106,6 @@ const async = require('async'),
             signer.update(dataFile);
             signer.end();
 
-            console.log("signature__")
             const signature = signer.sign(privateKey),
                 buff = Buffer.from(signature),
                 base64data = buff.toString('base64');
@@ -1590,7 +1588,6 @@ const async = require('async'),
     }
 
     function rewriteFileWoBOMAsUtf8(filePath, rewriteFlag, next) {
-        console.log("rewriteFileWoBOMAsUtf8__")
         let data = fs.readFileSync(filePath);
         const encodingFormat = chardet.detect(Buffer.from(data));
 

--- a/lib/package.js
+++ b/lib/package.js
@@ -633,9 +633,10 @@ const async = require('async'),
 
     function checkELFHeader(next) {
         log.verbose("checkELFHeader");
+        console.log("checkELFHeader__")
         const self = this,
             ELF_HEADER_LEN = 64,
-            buf = new Buffer(ELF_HEADER_LEN),
+            buf = Buffer.alloc(ELF_HEADER_LEN),
             mainFile = path.resolve(path.join(this.appDir, this.appinfo.main)),
             fd = fs.openSync(mainFile, 'r'),
             stats = fs.fstatSync(fd),
@@ -1106,8 +1107,9 @@ const async = require('async'),
             signer.update(dataFile);
             signer.end();
 
+            console.log("signature__")
             const signature = signer.sign(privateKey),
-                buff = new Buffer(signature),
+                buff = Buffer.from(signature),
                 base64data = buff.toString('base64');
 
             fs.writeFile(sigFilePath, base64data, next);
@@ -1588,8 +1590,9 @@ const async = require('async'),
     }
 
     function rewriteFileWoBOMAsUtf8(filePath, rewriteFlag, next) {
+        console.log("rewriteFileWoBOMAsUtf8__")
         let data = fs.readFileSync(filePath);
-        const encodingFormat = chardet.detect(new Buffer(data));
+        const encodingFormat = chardet.detect(Buffer.from(data));
 
         if (['UTF-8', 'ISO-8895-1'].indexOf(encodingFormat) === -1) {
             log.verbose("Current Encoding Type>> " + encodingFormat + "<<");


### PR DESCRIPTION
:Release Notes:
Update deprecated Buffer on node v14.15.1

:Detailed Notes:
Buffer() is deprecated on node v14.15.1,
so the API fixed to instead another APIs

:Testing Performed:
1. Before CLI test, change settings
  - Upgrade node version to v14.15.1
  - Remove node_modules
  - Re-install npm as 'npm install'
2. Check below commands to make sure it works without warning messages
  - node ares-package.js webapp
  - node ares-install.js com.domain.app_1.0.0_all.ipk
  - node ares-package.js -s ../spec/tempFiles/sign/signPriv.key
    -crt ../spec/tempFiles/sign/sign.crt webapp
3. Pass unit test on auto target and ose emulator
4. Pass eslint

:Issues Addressed:
[PLAT-129806] Update deprecated Buffer on node v14.15.1