### PR TITLE
Detect node warning in unit test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
         'expect' : false,
         'it' : false,
         'pending' :false,
-        'jasmine' : false
+        'jasmine' : false,
+        'fail' : false
     }
 };

--- a/spec/jsSpecs/ares-config.spec.js
+++ b/spec/jsSpecs/ares-config.spec.js
@@ -23,14 +23,20 @@ beforeAll(function (done) {
 
 describe(aresCmd + ' --profile(-p)', function() {
     it("Set a device profile to ose", function(done) {
-        exec(cmd + ' -p ose', function (error, stdout) {
+        exec(cmd + ' -p ose', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("profile and config data is changed to ose");
             done();
         });
     });
 
     it("Set a device profile input", function(done) {
-        exec(cmd + ` -p ${options.profile}`, function (error, stdout) {
+        exec(cmd + ` -p ${options.profile}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`profile and config data is changed to ${options.profile}`);
             done();
         });
@@ -39,7 +45,10 @@ describe(aresCmd + ' --profile(-p)', function() {
 
 describe(aresCmd + ' --prefile-details(-c)', function() {
     it("Set a device profile to configure", function(done) {
-        exec(cmd + ' -c', function (error, stdout) {
+        exec(cmd + ' -c', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Current profile set to ${options.profile}`, error);
             done();
         });

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -24,7 +24,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -49,7 +52,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device);
             done();
         });
@@ -61,7 +67,10 @@ describe(aresCmd, function() {
         const keys = ["webos_build_id","webos_imagename","webos_name","webos_release",
                     "webos_manufacturing_version", "core_os_kernel_version", "device_name",
                     "device_id", "chromium_version", "qt_version"];
-        exec(cmd + ` -i ${options.device}`, function (error, stdout) {
+        exec(cmd + ` -i ${options.device}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             keys.forEach(function(key) {
                 expect(stdout).toContain(key);
             });
@@ -74,7 +83,8 @@ describe(aresCmd, function() {
     it('Retrieve session information', function(done) {
         const keys = ["sessionId", "displayId"];
         exec(cmd + ` -s ${options.device}`, function (error, stdout, stderr) {
-            if (stderr.length > 0) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
                 expect(stderr).toContain("This device does not support the session.");
             }
             else {

--- a/spec/jsSpecs/ares-generate.spec.js
+++ b/spec/jsSpecs/ares-generate.spec.js
@@ -35,7 +35,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -45,7 +48,11 @@ describe(aresCmd + ' -v', function() {
 
 describe(aresCmd + ' --list', function() {
     it('List the available templates', function(done) {
-        exec(cmd + ' --list', function (error, stdout) {
+        exec(cmd + ' --list', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             expectedList = expectedList.join('\n'); // multi string in array. need to join
             stdout = stdout.trim().replace(/\s+['\n']/g, '\n');
             expect(stdout).toContain(expectedList);
@@ -70,7 +77,11 @@ describe(aresCmd +' --property', function() {
         const version = "2.0.0";
         const title = "First App";
 
-        exec(cmd + ` -t ${expectedTemplate.webapp} -p "id=${id}" -p "version=${version}" -p "title=${title}" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t ${expectedTemplate.webapp} -p "id=${id}" -p "version=${version}" -p "title=${title}" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text, outputObj;
             expect(fs.existsSync(path.join(sampleAppPath, "appinfo.json"))).toBe(true);
             try {
@@ -97,7 +108,11 @@ describe(aresCmd +' --property', function() {
         const version = "1.1.1";
         const test = "testData";
 
-        exec(cmd + ` -t packageinfo -p "id=${id}" -p "version=${version}" -p "test=${test}" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t packageinfo -p "id=${id}" -p "version=${version}" -p "test=${test}" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text, outputObj;
             expect(fs.existsSync(path.join(sampleAppPath, "packageinfo.json"))).toBe(true);
             try {
@@ -119,7 +134,11 @@ describe(aresCmd +' --property', function() {
         const id = "com.sample.app.service";
         const version = "1.1.1";
 
-        exec(cmd + ` -t jsserviceinfo -p "id=${id}" -p "version=${version}" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t jsserviceinfo -p "id=${id}" -p "version=${version}" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text, outputObj;
             expect(fs.existsSync(path.join(sampleAppPath, "services.json"))).toBe(true);
             try {
@@ -142,7 +161,11 @@ describe(aresCmd +' --property', function() {
         const version = "2.0.0";
         const title = "First App";
 
-        exec(cmd + ` -t ${expectedTemplate.qmlappinfo} -p "id=${id}" -p "version=${version}" -p "title=${title}" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t ${expectedTemplate.qmlappinfo} -p "id=${id}" -p "version=${version}" -p "title=${title}" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text, outputObj;
             expect(fs.existsSync(path.join(sampleAppPath, "appinfo.json"))).toBe(true);
             try {
@@ -172,7 +195,11 @@ describe(aresCmd + ' --template', function() {
     });
 
     it('webappinfo : appinfo.json for web app', function(done) {
-        exec(cmd + ` -t webappinfo -p "id=com.domain.app" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t webappinfo -p "id=com.domain.app" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             const fileList = [];
 
             expect(fs.existsSync(path.join(sampleAppPath))).toBe(true);
@@ -195,7 +222,11 @@ describe(aresCmd + ' --template', function() {
             pending("Skip packageinfo.json check");
         }
 
-        exec(cmd + ` -t packageinfo -p "id=com.domain" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t packageinfo -p "id=com.domain" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             const  fileList= [];
 
             expect(fs.existsSync(path.join(sampleAppPath))).toBe(true);
@@ -215,7 +246,11 @@ describe(aresCmd + ' --template', function() {
 
     it('hosted_webapp : generate qml template app', function(done) {
         const url = "http://www.google.com";
-        exec(cmd + ` -t hosted_webapp -p "url=${url}" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t hosted_webapp -p "url=${url}" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text;
             expect(fs.existsSync(path.join(sampleAppPath, "index.html"))).toBe(true);
             try {
@@ -231,7 +266,11 @@ describe(aresCmd + ' --template', function() {
     });
 
     it('qmlapp : generate qml template app', function(done) {
-        exec(cmd + ` -t qmlapp -p "id=com.qml.app" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t qmlapp -p "id=com.qml.app" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text;
             expect(fs.existsSync(path.join(sampleAppPath, "main.qml"))).toBe(true);
             try {
@@ -259,7 +298,11 @@ describe(aresCmd + ' --overwrite(-f)', function() {
     });
 
     it('generate sample app', function(done) {
-        exec(cmd + ` -t webappinfo -p "id=com.domain.app" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -t webappinfo -p "id=com.domain.app" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             const fileList = [];
 
             expect(fs.existsSync(path.join(sampleAppPath))).toBe(true);
@@ -278,7 +321,11 @@ describe(aresCmd + ' --overwrite(-f)', function() {
     });
 
     it('Overwirte existing files', function(done) {
-        exec(cmd + ` -f -t webappinfo -p "id=com.domain.app" ${sampleAppPath}`, function (error) {
+        exec(cmd + ` -f -t webappinfo -p "id=com.domain.app" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             const fileList = [];
 
             expect(fs.existsSync(path.join(sampleAppPath))).toBe(true);
@@ -309,7 +356,11 @@ describe(aresCmd + ' --servicename', function() {
 
     it('Set the servicename for webOS service.', function(done) {
         const serviceid = "com.domain.app.service";
-        exec(cmd + ` -t ${expectedTemplate.jsservice} -s ${serviceid} ${sampleServicePath}`, function (error) {
+        exec(cmd + ` -t ${expectedTemplate.jsservice} -s ${serviceid} ${sampleServicePath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let text, outputObj;
             expect(fs.existsSync(path.join(sampleServicePath, "services.json"))).toBe(true);
             try {

--- a/spec/jsSpecs/ares-inspect.spec.js
+++ b/spec/jsSpecs/ares-inspect.spec.js
@@ -24,7 +24,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -49,7 +52,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device, error);
             done();
         });
@@ -60,6 +66,9 @@ describe(aresCmd, function() {
     it('Install sample ipk to device', function(done) {
         const installCmd = common.makeCmd('ares-install');
         exec(installCmd + ` ${options.ipkPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Success", stderr);
             setTimeout(() => {
                 done();
@@ -74,14 +83,17 @@ describe(aresCmd, function() {
         let result = null;
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
-            expect(data.toString()).toContain('Application Debugging - http://localhost');
+            process.stdout.write(data);
+            result = data;
+            expect(data).toContain('Application Debugging - http://localhost');
         });
 
         child.stderr.on('data', function (data) {
-            expect(data.toString()).toBeNull(data.toString());
-            result = data.toString();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -93,7 +105,10 @@ describe(aresCmd, function() {
 
     it('Close sample App', function(done) {
         const launchCmd = common.makeCmd('ares-launch');
-        exec(launchCmd + ` -c ${options.pkgId} -dp 0`, function (error, stdout) {
+        exec(launchCmd + ` -c ${options.pkgId} -dp 0`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Closed application ${options.pkgId}`, error);
             setTimeout(function(){
                 done();
@@ -108,14 +123,17 @@ describe(aresCmd +' --open(-o)', function() {
         let result = null;
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
-            expect(data.toString()).toContain('Application Debugging - http://localhost');
+            process.stdout.write(data);
+            result = data;
+            expect(data).toContain('Application Debugging - http://localhost');
         });
 
         child.stderr.on('data', function (data) {
-            expect(data.toString()).toBeNull(data.toString());
-            result = data.toString();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -127,7 +145,10 @@ describe(aresCmd +' --open(-o)', function() {
 
     it('Close sample App', function(done) {
         const launchCmd = common.makeCmd('ares-launch');
-        exec(launchCmd + ` -c ${options.pkgId} -dp 1`, function (error, stdout) {
+        exec(launchCmd + ` -c ${options.pkgId} -dp 1`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Closed application ${options.pkgId}`, error);
             setTimeout(function(){
                 done();
@@ -143,15 +164,18 @@ describe(aresCmd, function() {
         const child = exec(cmd + ` -s ${options.pkgService} -dp 1`);
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
+            process.stdout.write(data);
+            result = data;
             expect(result).not.toContain("null");
             expect(result).toContain("localhost");
         });
 
         child.stderr.on('data', function (data) {
-            result = data.toString();
-            expect(data.toString()).toBeNull();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -172,15 +196,18 @@ describe(aresCmd +' --open(-o)', function() {
                             "nodeInsptUrl" ];
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
+            process.stdout.write(data);
             result = data.trim().replace(/\s+['\n']/g, '\n');
             expect(result).not.toContain("null");
             expect(guideTexts).toContain(String(result).split(":")[0]);
         });
 
         child.stderr.on('data', function (data) {
-            result = data.toString();
-            expect(data.toString()).toBeNull();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -194,6 +221,9 @@ describe(aresCmd, function() {
     it('Remove installed sample app with ares-install', function(done) {
         const installCmd = common.makeCmd('ares-install');
         exec(installCmd + ` -r ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Removed package ${options.pkgId}`, stderr);
             done();
         });

--- a/spec/jsSpecs/ares-install.spec.js
+++ b/spec/jsSpecs/ares-install.spec.js
@@ -24,7 +24,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -49,7 +52,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device);
             done();
         });
@@ -59,6 +65,9 @@ describe(aresCmd + ' --device-list(-D)', function() {
 describe(aresCmd, function() {
     it('Install sample ipk to device', function(done) {
         exec(cmd + ` ${options.ipkPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Success", stderr);
             done();
         });
@@ -68,6 +77,9 @@ describe(aresCmd, function() {
 describe(aresCmd + ' --list(-l)', function() {
     it('List the installed apps on device', function(done) {
         exec(cmd + ' -l', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.pkgId, stderr);
             done();
         });
@@ -77,6 +89,9 @@ describe(aresCmd + ' --list(-l)', function() {
 describe(aresCmd + ' --listfull(-F)', function() {
     it('List the installed apps detail information', function(done) {
         exec(cmd + ' -F', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.pkgId, stderr);
             expect(stdout).toContain("version:0.0.1");
             done();
@@ -87,6 +102,9 @@ describe(aresCmd + ' --listfull(-F)', function() {
 describe(aresCmd + ' --remove(-r)', function() {
     it('Remove installed sample app', function(done) {
         exec(cmd + ` -r ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Removed package ${options.pkgId}`, stderr);
             done();
         });
@@ -96,6 +114,9 @@ describe(aresCmd + ' --remove(-r)', function() {
 describe(aresCmd + ' --list(-l)', function() {
     it('Check removed app is not on installed List', function(done) {
         exec(cmd + ' -l', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).not.toContain(options.pkgId, stderr);
             done();
         });

--- a/spec/jsSpecs/ares-launch.spec.js
+++ b/spec/jsSpecs/ares-launch.spec.js
@@ -30,7 +30,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -55,7 +58,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device);
             done();
         });
@@ -66,6 +72,9 @@ describe(aresCmd, function() {
     it('Install sample ipk to device with ares-install', function(done) {
         const installCmd = common.makeCmd('ares-install');
         exec(installCmd + ` ${options.ipkPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Success", stderr);
             setTimeout(function(){
                 done();
@@ -76,7 +85,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd, function() {
     it('Launch sample App', function(done) {
-        exec(cmd + ` ${options.pkgId}`, function (error, stdout) {
+        exec(cmd + ` ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Launched application ${options.pkgId}`, error);
             setTimeout(function(){
                 done();
@@ -87,7 +99,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --running(-r)', function() {
     it('Check sample app in running list', function(done) {
-        exec(cmd + ' -r', function (error, stdout) {
+        exec(cmd + ' -r', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`${options.pkgId}`);
             done();
         });
@@ -96,7 +111,10 @@ describe(aresCmd + ' --running(-r)', function() {
 
 describe(aresCmd + ' --close(-c)', function() {
     it('Close sample app', function(done) {
-        exec(cmd + ` -c ${options.pkgId}`, function (error, stdout) {
+        exec(cmd + ` -c ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`${options.pkgId}`);
             setTimeout(function(){
                 done();
@@ -107,7 +125,10 @@ describe(aresCmd + ' --close(-c)', function() {
 
 describe(aresCmd + ' with --display(-dp) option', function() {
     it('Launch sample App', function(done) {
-        exec(cmd + ` -dp 1 ${options.pkgId}`, function (error, stdout) {
+        exec(cmd + ` -dp 1 ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Launched application ${options.pkgId}`, error);
             expect(stdout).toContain("on display 1");
             setTimeout(function(){
@@ -119,7 +140,10 @@ describe(aresCmd + ' with --display(-dp) option', function() {
 
 describe(aresCmd + ' --running(-r) with --display(-dp) option', function() {
     it('Check sample app in running list', function(done) {
-        exec(cmd + ' -r -dp 1', function (error, stdout) {
+        exec(cmd + ' -r -dp 1', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`${options.pkgId}`);
             expect(stdout).toContain("- display 1");
             done();
@@ -129,7 +153,10 @@ describe(aresCmd + ' --running(-r) with --display(-dp) option', function() {
 
 describe(aresCmd + ' --close(-c) with --display(-dp) option', function() {
     it('Close sample app', function(done) {
-        exec(cmd + ` -c -dp 1 ${options.pkgId}`, function (error, stdout) {
+        exec(cmd + ` -c -dp 1 ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`${options.pkgId}`);
             expect(stdout).toContain("on display 1");
             setTimeout(function(){
@@ -141,7 +168,10 @@ describe(aresCmd + ' --close(-c) with --display(-dp) option', function() {
 
 describe(aresCmd + ' with -p "{\'displayAffinity\':1}" option', function() {
     it('Launch sample App', function(done) {
-        exec(cmd + ` -p "{'displayAffinity':0}" ${options.pkgId}`, function (error, stdout) {
+        exec(cmd + ` -p "{'displayAffinity':0}" ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Launched application ${options.pkgId}`, error);
             expect(stdout).toContain("on display 0");
             setTimeout(function(){
@@ -153,7 +183,10 @@ describe(aresCmd + ' with -p "{\'displayAffinity\':1}" option', function() {
 
 describe(aresCmd + ' --close(-c) p "{\'displayAffinity\':1}" option', function() {
     it('Close sample app', function(done) {
-        exec(cmd + ` -c -p "{'displayAffinity':0}" ${options.pkgId}`, function (error, stdout) {
+        exec(cmd + ` -c -p "{'displayAffinity':0}" ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`${options.pkgId}`);
             expect(stdout).toContain("on display 0");
             setTimeout(function(){
@@ -167,6 +200,9 @@ describe(aresCmd, function() {
     it('Remove installed sample app with ares-install', function(done) {
         const installCmd = common.makeCmd('ares-install');
         exec(installCmd + ` -r ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Removed package ${options.pkgId}`, stderr);
             done();
         });
@@ -185,7 +221,10 @@ describe(aresCmd +' --hosted(-H)', function() {
 
     it('Generate SampleApp', function(done) {
         const generateCmd = common.makeCmd('ares-generate');
-        exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.sample.app" ${sampleAppPath}`, function (error, stdout) {
+        exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.sample.app" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Generating ${expectedTemplate.webapp}`);
             expect(error).toBeNull();
             done();
@@ -193,22 +232,37 @@ describe(aresCmd +' --hosted(-H)', function() {
     });
 
     it('Launch -H SampleApp', function(done) {
-        let result;
-        const child = exec(cmd + ` -H ${sampleAppPath}`, function (error, stdout) {
-            expect(stdout).toContain('Ares Hosted App is now running');
-            done();
+        let result = "";
+        const child = exec(cmd + ` -H ${sampleAppPath}`);
+        
+        child.stdout.on('data', function (data) {
+            process.stdout.write(data);
+            result += data;
+        });
+
+        child.stderr.on('data', function (data) {
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result += data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
+            expect(result).toContain('Ares Hosted App is now running');
             expect(result).not.toBeNull();
             done();
         }, 3000);
     });
 
+
     it('Remove installed ares-hosted app with ares-install', function(done) {
         const installCmd = common.makeCmd('ares-install');
         exec(installCmd + ' -r com.sdk.ares.hostedapp', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Removed package com.sdk.ares.hostedapp`, stderr);
             done();
         });

--- a/spec/jsSpecs/ares-package.spec.js
+++ b/spec/jsSpecs/ares-package.spec.js
@@ -48,7 +48,7 @@ describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 expect(stderr).toContain("verb argv");
             }
             expect(stdout).toContain("SYNOPSIS");
@@ -68,7 +68,7 @@ describe(aresCmd, function() {
         const generateCmd = common.makeCmd('ares-generate');
         exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.webos.sample.app" -p "version=1.0.0" ${sampleAppPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Generating");
             expect(error).toBeNull();
@@ -91,7 +91,7 @@ describe(aresCmd, function() {
             const generateCmd = common.makeCmd('ares-generate');
             exec(generateCmd + ` -t ${expectedTemplate.jsservice} -s ${svcId} ${svcPath}`, function (error, stdout, stderr) {
                 if (stderr && stderr.length > 0) {
-                    commonSpec.detectNodeMessage(stderr);
+                    common.detectNodeMessage(stderr);
                 }
                 expect(stdout).toContain("Generating");
                 done();
@@ -132,7 +132,7 @@ describe(aresCmd, function() {
     it('Package web app & service with -o(--outdir)', function(done) {
         exec(cmd + ` ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain(outputPath);
             expect(stdout).toContain("Success", error);
@@ -160,7 +160,7 @@ describe(aresCmd, function() {
     it('App version does not exist', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
@@ -183,7 +183,7 @@ describe(aresCmd, function() {
 
         exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
@@ -201,7 +201,7 @@ describe(aresCmd, function() {
 
         exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
@@ -219,7 +219,7 @@ describe(aresCmd, function() {
 
         exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
@@ -237,7 +237,7 @@ describe(aresCmd, function() {
 
         exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
@@ -257,7 +257,7 @@ describe(aresCmd, function() {
     it('Package Only Service with -o(--outdir)', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain(outputPath);
             expect(stdout).toContain("Success", error);
@@ -280,7 +280,7 @@ describe(aresCmd, function() {
     it('Package Only Service by packageinfo.json with -o(--outdir)', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain(outputPath);
             expect(stdout).toContain("Success", error);
@@ -294,7 +294,7 @@ describe(aresCmd + ' --check(-c)', function() {
     it('Check the application but do not pacakge', function(done) {
         exec(cmd + ` -c ${sampleAppPath} ${sampleServicePaths[0]}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("no problems detected");
             done();
@@ -303,7 +303,7 @@ describe(aresCmd + ' --check(-c)', function() {
     it('Check the services but do not pacakge', function(done) {
         exec(cmd + ` -c ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("no problems detected");
             done();
@@ -325,7 +325,7 @@ describe(aresCmd + ' --rom(-r)', function() {
     it('Create output a directory structure with app', function(done) {
         exec(cmd + ` -r ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
 
             const createdSvcPath = path.join(outputPath, 'usr/palm/services');
@@ -339,7 +339,7 @@ describe(aresCmd + ' --rom(-r)', function() {
     it('Create output a directory structure without app', function(done) {
         exec(cmd + ` -r ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
 
             const createdSvcPath = path.join(outputPath, 'usr/palm/services');
@@ -364,7 +364,7 @@ describe(aresCmd + ' --encrypt(-enc)', function() {
     it('Encrypted ipk', function(done) {
         exec(cmd + ` -enc ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 expect(stderr).toContain('no such file or directory, open');
             }
             expect(fs.existsSync(appPkgPath)).toBe(false);
@@ -387,7 +387,7 @@ describe(aresCmd + ' --sign(-s) & --certificate(-crt)', function() {
     it('Sign ipk', function(done) {
         exec(cmd +` -s ${signKeyPath} -crt ${crtPath} ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain('Create signed', error);
             expect(fs.existsSync(appPkgPath)).toBe(true);
@@ -413,7 +413,7 @@ describe(aresCmd + ' --app-exclude(-e)', function() {
     it('Check the application but do not pacakge', function(done) {
         exec(cmd + ` -e tmpFile ${sampleAppPath} -r -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain("Success");
             expect(fs.existsSync(path.join(appPathByRom, "com.webos.sample.app/tmpFile"))).toBe(false);
@@ -439,7 +439,7 @@ describe(aresCmd + ' negative TC', function() {
     it('Check to exist app id', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);
             }
@@ -462,7 +462,7 @@ describe(aresCmd + ' negative TC', function() {
     it('Check to exist required fields in app meta file', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: Invalid file <appinfo.json> :\nmain is required\ntitle is required\nicon is required" +
                                         "\ntype is required", error);
@@ -490,7 +490,7 @@ describe(aresCmd + ' negative TC', function() {
     it('Check to invalid app type', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: Invalid file <appinfo.json> :" +
                                         "\ntype is not one of enum values: web,stub,native,native_builtin,native_appshell,qml", error);
@@ -509,7 +509,7 @@ describe(aresCmd + ' negative TC', function() {
     it('Check pi/pn option for app packaging', function(done) {
         exec(cmd + ` ${sampleAppPath} -pi com.webos.sample -pv 1.1.1 -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: Do not use together with options <pkgid, pkgversion, pkginfofile>", error);
             }
@@ -527,7 +527,7 @@ describe(aresCmd + ' negative TC for services packaging', function() {
     it('Check to exist pi option', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: packageId must be provided by using either the '--pkgid' or the '--pkginfofile' option", error);
             }
@@ -545,7 +545,7 @@ describe(aresCmd + ' negative TC for services packaging', function() {
     it('Check to do not support -pi and -pf options together', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -pi com.webos.sample -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: Do not use together with options <pkginfofile, pkgid>", error);
             }
@@ -574,7 +574,7 @@ describe(aresCmd + ' negative TC for services packaging', function() {
     it('Check to file name of package meta file', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${tmpPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr.trim().replace(/\s+['\n']/g, '\n');
                 expect(stderr).toContain("ares-package ERR! CLI: Invalid file <packageinfo.json> ", error);
             }
@@ -603,7 +603,7 @@ describe(aresCmd + ' negative TC for services packaging', function() {
     it('Check to exist id fields in pkg meta file', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -o ${outputPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
-                commonSpec.detectNodeMessage(stderr);
+                common.detectNodeMessage(stderr);
                 stderr.trim().replace(/\s+['\n']/g, '\n');
                 console.log("stderr:"+stderr)
                 expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);

--- a/spec/jsSpecs/ares-package.spec.js
+++ b/spec/jsSpecs/ares-package.spec.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const commonSpec = require('./common-spec');
+
 const path = require('path'),
     fs = require('fs'),
     exec = require('child_process').exec,
@@ -47,7 +49,10 @@ afterAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -63,7 +68,10 @@ describe(aresCmd, function() {
 
     it('Generate a sample app for packaging', function(done) {
         const generateCmd = common.makeCmd('ares-generate');
-        exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.webos.sample.app" -p "version=1.0.0" ${sampleAppPath}`, function (error, stdout) {
+        exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.webos.sample.app" -p "version=1.0.0" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Generating");
             expect(error).toBeNull();
             done();
@@ -83,7 +91,10 @@ describe(aresCmd, function() {
             const svcPath = path.join(sampleServicePath, svcId);
             sampleServicePaths.push(path.join(sampleServicePath, svcId));
             const generateCmd = common.makeCmd('ares-generate');
-            exec(generateCmd + ` -t ${expectedTemplate.jsservice} -s ${svcId} ${svcPath}`, function (error, stdout) {
+            exec(generateCmd + ` -t ${expectedTemplate.jsservice} -s ${svcId} ${svcPath}`, function (error, stdout, stderr) {
+                if (stderr && stderr.length > 0) {
+                    commonSpec.detectNodeMessage(stderr);
+                }
                 expect(stdout).toContain("Generating");
                 done();
             });
@@ -102,7 +113,10 @@ describe(aresCmd, function() {
     });
 
     it('Package web app with -o(--outdir)', function(done) {
-        exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
             expect(fs.existsSync(appPkgPath)).toBe(true);
@@ -118,7 +132,10 @@ describe(aresCmd, function() {
     });
 
     it('Package web app & service with -o(--outdir)', function(done) {
-        exec(cmd + ` ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(outputPath);
             expect(stdout).toContain("Success", error);
             expect(fs.existsSync(appPkgPath)).toBe(true);
@@ -143,7 +160,10 @@ describe(aresCmd, function() {
     });
 
     it('App version does not exist', function(done) {
-        exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
             expect(fs.existsSync(appPkgPath)).toBe(true);
@@ -163,7 +183,10 @@ describe(aresCmd, function() {
         const expectIpkName = "com.ose.target.native_1.0.0_arm.ipk";
         const expectIpkPath =  path.join(outputPath, expectIpkName);
 
-        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
             expect(stdout).toContain(expectIpkName, error);
@@ -178,7 +201,10 @@ describe(aresCmd, function() {
         const expectIpkName = "com.ose.emul.native_1.0.0_x86.ipk";
         const expectIpkPath =  path.join(outputPath, expectIpkName);
 
-        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
             expect(stdout).toContain(expectIpkName, error);
@@ -193,7 +219,10 @@ describe(aresCmd, function() {
         const expectIpkName = "com.sample.gles2_1.0.0_aarch64.ipk";
         const expectIpkPath =  path.join(outputPath, expectIpkName);
 
-        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
             expect(stdout).toContain(expectIpkName, error);
@@ -208,7 +237,10 @@ describe(aresCmd, function() {
         const expectIpkName = "com.sample.gles2_1.0.0_x86_64.ipk";
         const expectIpkPath =  path.join(outputPath, expectIpkName);
 
-        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${nativeAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Create", error);
             expect(stdout).toContain("Success", error);
             expect(stdout).toContain(expectIpkName, error);
@@ -225,7 +257,10 @@ describe(aresCmd, function() {
     });
 
     it('Package Only Service with -o(--outdir)', function(done) {
-        exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(outputPath);
             expect(stdout).toContain("Success", error);
             expect(fs.existsSync(svcPkgPath)).toBe(true);
@@ -245,7 +280,10 @@ describe(aresCmd, function() {
         done();
     });
     it('Package Only Service by packageinfo.json with -o(--outdir)', function(done) {
-        exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(outputPath);
             expect(stdout).toContain("Success", error);
             expect(fs.existsSync(svcPkgPath)).toBe(true);
@@ -256,13 +294,19 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --check(-c)', function() {
     it('Check the application but do not pacakge', function(done) {
-        exec(cmd + ` -c ${sampleAppPath} ${sampleServicePaths[0]}`, function (error, stdout) {
+        exec(cmd + ` -c ${sampleAppPath} ${sampleServicePaths[0]}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("no problems detected");
             done();
         });
     });
     it('Check the services but do not pacakge', function(done) {
-        exec(cmd + ` -c ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample`, function (error, stdout) {
+        exec(cmd + ` -c ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("no problems detected");
             done();
         });
@@ -281,7 +325,11 @@ describe(aresCmd + ' --rom(-r)', function() {
     });
 
     it('Create output a directory structure with app', function(done) {
-        exec(cmd + ` -r ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` -r ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
+
             const createdSvcPath = path.join(outputPath, 'usr/palm/services');
             expect(stdout).toContain('Create output directory');
             expect(fs.existsSync(appPathByRom)).toBe(true);
@@ -291,7 +339,11 @@ describe(aresCmd + ' --rom(-r)', function() {
     });
 
     it('Create output a directory structure without app', function(done) {
-        exec(cmd + ` -r ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` -r ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pi com.webos.sample -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
+
             const createdSvcPath = path.join(outputPath, 'usr/palm/services');
             expect(stdout).toContain('Create output directory');
             expect(fs.existsSync(createdSvcPath)).toBe(true);
@@ -313,7 +365,10 @@ describe(aresCmd + ' --encrypt(-enc)', function() {
 
     it('Encrypted ipk', function(done) {
         exec(cmd + ` -enc ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
-            expect(stderr).toContain('no such file or directory, open');
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                expect(stderr).toContain('no such file or directory, open');
+            }
             expect(fs.existsSync(appPkgPath)).toBe(false);
             done();
         });
@@ -332,7 +387,10 @@ describe(aresCmd + ' --sign(-s) & --certificate(-crt)', function() {
     });
 
     it('Sign ipk', function(done) {
-        exec(cmd +` -s ${signKeyPath} -crt ${crtPath} ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout) {
+        exec(cmd +` -s ${signKeyPath} -crt ${crtPath} ${sampleAppPath} ${sampleServicePaths[0]} -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain('Create signed', error);
             expect(fs.existsSync(appPkgPath)).toBe(true);
             done();
@@ -355,7 +413,10 @@ describe(aresCmd + ' --app-exclude(-e)', function() {
     });
 
     it('Check the application but do not pacakge', function(done) {
-        exec(cmd + ` -e tmpFile ${sampleAppPath} -r -o ${outputPath}`, function (error, stdout) {
+        exec(cmd + ` -e tmpFile ${sampleAppPath} -r -o ${outputPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("Success");
             expect(fs.existsSync(path.join(appPathByRom, "com.webos.sample.app/tmpFile"))).toBe(false);
             done();
@@ -379,8 +440,11 @@ describe(aresCmd + ' negative TC', function() {
 
     it('Check to exist app id', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);
+            }
             done();
         });
     });
@@ -399,9 +463,12 @@ describe(aresCmd + ' negative TC', function() {
 
     it('Check to exist required fields in app meta file', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Invalid file <appinfo.json> :\nmain is required\ntitle is required\nicon is required" +
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: Invalid file <appinfo.json> :\nmain is required\ntitle is required\nicon is required" +
                                         "\ntype is required", error);
+            }
             done();
         });
     });
@@ -424,9 +491,12 @@ describe(aresCmd + ' negative TC', function() {
 
     it('Check to invalid app type', function(done) {
         exec(cmd + ` ${sampleAppPath} -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Invalid file <appinfo.json> :" +
-                                    "\ntype is not one of enum values: web,stub,native,native_builtin,native_appshell,qml", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: Invalid file <appinfo.json> :" +
+                                        "\ntype is not one of enum values: web,stub,native,native_builtin,native_appshell,qml", error);
+            }
             done();
         });
     });
@@ -440,8 +510,11 @@ describe(aresCmd + ' negative TC', function() {
 
     it('Check pi/pn option for app packaging', function(done) {
         exec(cmd + ` ${sampleAppPath} -pi com.webos.sample -pv 1.1.1 -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Do not use together with options <pkgid, pkgversion, pkginfofile>", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr = stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: Do not use together with options <pkgid, pkgversion, pkginfofile>", error);
+            }
             done();
         });
     });
@@ -455,8 +528,11 @@ describe(aresCmd + ' negative TC for services packaging', function() {
 
     it('Check to exist pi option', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: packageId must be provided by using either the '--pkgid' or the '--pkginfofile' option", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: packageId must be provided by using either the '--pkgid' or the '--pkginfofile' option", error);
+            }
             done();
         });
     });
@@ -470,8 +546,11 @@ describe(aresCmd + ' negative TC for services packaging', function() {
 
     it('Check to do not support -pi and -pf options together', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -pi com.webos.sample -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Do not use together with options <pkginfofile, pkgid>", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: Do not use together with options <pkginfofile, pkgid>", error);
+            }
             done();
         });
     });
@@ -496,8 +575,11 @@ describe(aresCmd + ' negative TC for services packaging', function() {
 
     it('Check to file name of package meta file', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${tmpPath} -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Invalid file <packageinfo.json> ", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr.trim().replace(/\s+['\n']/g, '\n');
+                expect(stderr).toContain("ares-package ERR! CLI: Invalid file <packageinfo.json> ", error);
+            }
             done();
         });
     });
@@ -522,8 +604,12 @@ describe(aresCmd + ' negative TC for services packaging', function() {
 
     it('Check to exist id fields in pkg meta file', function(done) {
         exec(cmd + ` ${sampleServicePaths[1]} ${sampleServicePaths[2]} -pf ${pkginfoPath} -o ${outputPath}`, function (error, stdout, stderr) {
-            stderr.trim().replace(/\s+['\n']/g, '\n');
-            expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);
+            if (stderr && stderr.length > 0) {
+                commonSpec.detectNodeMessage(stderr);
+                stderr.trim().replace(/\s+['\n']/g, '\n');
+                console.log("stderr:"+stderr)
+                expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);
+            }
             done();
         });
     });

--- a/spec/jsSpecs/ares-package.spec.js
+++ b/spec/jsSpecs/ares-package.spec.js
@@ -605,7 +605,6 @@ describe(aresCmd + ' negative TC for services packaging', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
                 stderr.trim().replace(/\s+['\n']/g, '\n');
-                console.log("stderr:"+stderr)
                 expect(stderr).toContain("ares-package ERR! CLI: Please input required field <id>", error);
             }
             done();

--- a/spec/jsSpecs/ares-package.spec.js
+++ b/spec/jsSpecs/ares-package.spec.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const commonSpec = require('./common-spec');
-
 const path = require('path'),
     fs = require('fs'),
     exec = require('child_process').exec,

--- a/spec/jsSpecs/ares-pull.spec.js
+++ b/spec/jsSpecs/ares-pull.spec.js
@@ -26,7 +26,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -51,7 +54,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device);
             done();
         });
@@ -67,7 +73,10 @@ describe(aresCmd, function() {
     });
 
     it('Copy directory from a device to host machine', function(done) {
-        exec(cmd + ` /tmp/aresfile ${dstPath}`, function (error, stdout) {
+        exec(cmd + ` /tmp/aresfile ${dstPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(dstPath);
             expect(stdout).toContain("1 file(s) pulled");
             done();
@@ -77,7 +86,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --ignore(-i)', function() {
     it('Copy directory from a device to host machine', function(done) {
-        exec(cmd + ` -i /tmp/aresfile ${dstPath}`, function (error, stdout) {
+        exec(cmd + ` -i /tmp/aresfile ${dstPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).not.toContain(dstPath);
             expect(stdout).toContain("1 file(s) pulled");
             done();

--- a/spec/jsSpecs/ares-push.spec.js
+++ b/spec/jsSpecs/ares-push.spec.js
@@ -26,7 +26,7 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            expect(stderr).toContain("verb argv");
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -51,7 +51,10 @@ describe(aresCmd, function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device);
             done();
         });
@@ -67,7 +70,10 @@ describe(aresCmd, function() {
     });
 
     it('Copy directory', function(done) {
-        exec(cmd + ` ${srcPath} /tmp`, function (error, stdout) {
+        exec(cmd + ` ${srcPath} /tmp`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain("/tmp/copyFiles/testFile.txt");
             expect(stdout).toContain("/tmp/copyFiles/helloFile.txt");
             expect(stdout).toContain("2 file(s) pushed");
@@ -86,7 +92,10 @@ describe(aresCmd + " --ignore(-i) ", function() {
     });
 
     it('Copy directory with -i', function(done) {
-        exec(cmd + ` -i ${srcPath} /tmp`, function (error, stdout) {
+        exec(cmd + ` -i ${srcPath} /tmp`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).not.toContain("/tmp/copyFiles/testFile.txt");
             expect(stdout).not.toContain("/tmp/copyFiles/helloFile.txt");
             expect(stdout).toContain("2 file(s) pushed");

--- a/spec/jsSpecs/ares-server.spec.js
+++ b/spec/jsSpecs/ares-server.spec.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const commonSpec = require('./common-spec');
-
 const path = require('path'),
     fs = require('fs'),
     exec = require('child_process').exec,
@@ -76,7 +74,7 @@ describe(aresCmd, function() {
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
             result = data;
-            expect(result).toContain('Local server running on http://localhost');
+            expect(data).toContain('Local server running on http://localhost');
         });
 
         child.stderr.on('data', function (data) {

--- a/spec/jsSpecs/ares-server.spec.js
+++ b/spec/jsSpecs/ares-server.spec.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const commonSpec = require('./common-spec');
+
 const path = require('path'),
     fs = require('fs'),
     exec = require('child_process').exec,
@@ -27,7 +29,10 @@ beforeAll(function (done) {
 describe(aresCmd + ' -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -43,7 +48,11 @@ describe(aresCmd, function() {
 
     it('Generate sample app', function(done) {
         const generateCmd = common.makeCmd('ares-generate');
-        exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.domain.app" ${sampleAppPath}`, function (error) {
+        exec(generateCmd + ` -t ${expectedTemplate.webapp} -p "id=com.domain.app" ${sampleAppPath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             let outputObj;
             try {
                 const text = fs.readFileSync(path.join(sampleAppPath, "appinfo.json"));
@@ -65,14 +74,17 @@ describe(aresCmd, function() {
         let result;
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
-            expect(data.toString()).toContain('Local server running on http://localhost');
+            process.stdout.write(data);
+            result = data;
+            expect(result).toContain('Local server running on http://localhost');
         });
 
         child.stderr.on('data', function (data) {
-            result = data.toString();
-            expect(data.toString()).toBeNull();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -89,14 +101,17 @@ describe(aresCmd + ' --open(o)', function() {
         let result;
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
-            expect(data.toString()).toContain('Local server running on http://localhost');
+            process.stdout.write(data);
+            result = data;
+            expect(data).toContain('Local server running on http://localhost');
         });
 
         child.stderr.on('data', function (data) {
-            result = data.toString();
-            expect(data.toString()).toBeNull();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -119,14 +134,17 @@ describe(aresCmd +' --port', function() {
         let result;
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
-            expect(data.toString()).toContain(`Local server running on http://localhost:${port}`);
+            process.stdout.write(data);
+            result = data;
+            expect(data).toContain(`Local server running on http://localhost:${port}`);
         });
 
         child.stderr.on('data', function (data) {
-            result = data.toString();
-            expect(data.toString()).toBeNull();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {

--- a/spec/jsSpecs/ares-setup-device.spec.js
+++ b/spec/jsSpecs/ares-setup-device.spec.js
@@ -53,7 +53,10 @@ const killUsedPort = function() {
 describe(aresCmd + ' -h -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -h -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -66,7 +69,10 @@ describe(aresCmd + ' --add(-a)', function() {
         const host = '192.168.0.5';
         const port = '1234';
         const username = 'developer';
-        exec(cmd + ` -a ${device} -i username=${username} -i host=${host} -i port=${port}`, function (error, stdout) {
+        exec(cmd + ` -a ${device} -i username=${username} -i host=${host} -i port=${port}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(device);
             expect(stdout).toContain(host);
             expect(stdout).toContain(port);
@@ -84,7 +90,10 @@ describe(aresCmd + ' --add(-a)', function() {
         const port = '1234';
         const username = 'developer';
         const newDevice = 'test1';
-        exec(cmd + ` -a ${newDevice} -i username=${username} -i host=${host} -i port=${port} -i default=true`, function (error, stdout) {
+        exec(cmd + ` -a ${newDevice} -i username=${username} -i host=${host} -i port=${port} -i default=true`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(newDevice);
             expect(stdout).toContain(host);
             expect(stdout).toContain(port);
@@ -97,7 +106,10 @@ describe(aresCmd + ' --add(-a)', function() {
 
 describe(aresCmd + ' --list(-l)', function() {
     it('Should List all device information', function(done) {
-        exec(cmd + ' --list', function (error, stdout) {
+        exec(cmd + ' --list', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(device);
             done();
         });
@@ -106,7 +118,10 @@ describe(aresCmd + ' --list(-l)', function() {
 
 describe(aresCmd + ' --listfull(-F)', function() {
     it('Should List all device detail information', function(done) {
-        exec(cmd + ' -F', function (error, stdout) {
+        exec(cmd + ' -F', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(device);
             expect(stdout).toContain("description");
             done();
@@ -119,7 +134,10 @@ describe(aresCmd + ' --modify(-m)', function() {
         const username = 'developer';
         const host = '192.168.0.1';
         const port = '4321';
-        exec(cmd + ` -m ${device} -i username=${username} -i host=${host} -i port=${port}`, function (error, stdout) {
+        exec(cmd + ` -m ${device} -i username=${username} -i host=${host} -i port=${port}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(username);
             expect(stdout).toContain(host);
             expect(stdout).toContain(port);
@@ -130,7 +148,10 @@ describe(aresCmd + ' --modify(-m)', function() {
 
 describe(aresCmd + ' --default(-f)', function() {
     it('Set default device', function(done) {
-        exec(cmd + ` -f ${device}`, function (error, stdout) {
+        exec(cmd + ` -f ${device}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(device + " (default)");
             done();
         });
@@ -139,7 +160,10 @@ describe(aresCmd + ' --default(-f)', function() {
 
 describe(aresCmd + ' --remove(-r)', function() {
     it('Should remove added device information', function(done) {
-        exec(cmd + ` -r ${device}`, function (error, stdout) {
+        exec(cmd + ` -r ${device}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).not.toContain(device);
             expect(error).toBeNull();
             expect(stdout).not.toContain(device);
@@ -165,17 +189,20 @@ describe(aresCmd + ' --search(-s), --timeout(-t)', function() {
         let result;
 
         child.stdout.on('data', function (data) {
-            process.stdout.write(data.toString());
-            result = data.toString();
+            process.stdout.write(data);
+            result = data;
             if(!checkDone) {
-                expect(data.toString()).toContain("Searching...");
+                expect(data).toContain("Searching...");
                 checkDone = true;
             }
         });
 
         child.stderr.on('data', function (data) {
-            result = data.toString();
-            expect(data.toString()).toBeNull();
+            if (data && data.length > 0) {
+                common.detectNodeMessage(data);
+            }
+            result = data;
+            expect(data).toBeNull();
         });
 
         setTimeout(() => {
@@ -190,7 +217,10 @@ describe(aresCmd + ' --reset(-R)', function() {
         const host = '192.168.0.5';
         const port = '1234';
         const username = 'developer';
-        exec(cmd + ` -a ${device} -i username=${username} -i host=${host} -i port=${port}`, function (error, stdout) {
+        exec(cmd + ` -a ${device} -i username=${username} -i host=${host} -i port=${port}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(device);
             expect(stdout).toContain(host);
             expect(stdout).toContain(port);
@@ -208,7 +238,10 @@ describe(aresCmd + ' --reset(-R)', function() {
             }
         });
 
-        exec(cmd + ' -R', function (error, stdout) {
+        exec(cmd + ' -R', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(initDevice.name +" (default)");
             expect(stdout).toContain(initDevice.username);
             expect(stdout).toContain(initDevice.host);

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -39,7 +39,10 @@ describe(aresCmd, function() {
 describe(aresCmd + ' -h -v', function() {
     it('Print help message with verbose log', function(done) {
         exec(cmd + ' -h -v', function (error, stdout, stderr) {
-            expect(stderr.toString()).toContain("verb argv");
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("verb argv");
+            }
             expect(stdout).toContain("SYNOPSIS");
             expect(error).toBeNull();
             done();
@@ -49,7 +52,10 @@ describe(aresCmd + ' -h -v', function() {
 
 describe(aresCmd + ' --device-list(-D)', function() {
     it('Show available device list', function(done) {
-        exec(cmd + ' -D', function (error, stdout) {
+        exec(cmd + ' -D', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(options.device);
             done();
         });
@@ -58,7 +64,10 @@ describe(aresCmd + ' --device-list(-D)', function() {
 
 describe(aresCmd, function() {
     it('Open shell on default device', function(done) {
-        exec(cmd, function (error, stdout) {
+        exec(cmd, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(stdout).toContain(`Start ${options.device} shell`, error);
             done();
         });
@@ -68,6 +77,10 @@ describe(aresCmd, function() {
 describe(aresCmd + ' --display(-dp)', function() {
     it('Set display', function(done) {
         exec(cmd + ' -dp 1', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             if (options.device === "emulator") { // emulator's default setting user is "developer"
                 expect(stderr).toContain("Unable to connect to the target device. root access required <connect user session>", error);
             }
@@ -83,6 +96,10 @@ describe(aresCmd + ' --run', function() {
     it('Run CMD', function(done) {
         // eslint-disable-next-line no-useless-escape
         exec(cmd + ' -dp 1 -r \"echo hello webOS\"', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
             if (options.device === "emulator") { // emulator's default setting user is "developer"
                 expect(stderr).toContain("Unable to connect to the target device. root access required <connect user session>", error);
             } else {

--- a/spec/jsSpecs/ares.spec.js
+++ b/spec/jsSpecs/ares.spec.js
@@ -26,7 +26,10 @@ beforeAll(function (done) {
 // ares command test
 describe(aresCmd + ' --list(-l)', function() {
     it('Should show all the ares commands', function(done) {
-        exec(cmd + ' --list', function (error, stdout) {
+        exec(cmd + ' --list', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             // get expected list
             expectedList = expectedList.join('\n'); // multi string in array. need to join
             stdout = stdout.trim().replace(/\s+['\n']/g, '\n');
@@ -38,7 +41,10 @@ describe(aresCmd + ' --list(-l)', function() {
 
 describe(aresCmd + ' --version(-v)', function() {
     it('Check version info with package.json', function(done) {
-        exec(cmd + ' --version', function (error, stdout) {
+        exec(cmd + ' --version', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             // get CLI version
             const text = fs.readFileSync(path.join(__dirname, "../../", "package.json"), 'utf8');
             const pkgInfoObj = JSON.parse(text);
@@ -51,7 +57,10 @@ describe(aresCmd + ' --version(-v)', function() {
 
 describe(aresCmd + ' --<COMMAND>', function() {
     it('Display the help information of the generate', function(done) {
-        exec(cmd + ' -generate', function (error) {
+        exec(cmd + ' -generate', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
             expect(error).toBeNull();
             done();
         });

--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -115,4 +115,4 @@ commonSpec.detectNodeMessage = function(stderr) {
     if (stderr.includes("node:")) {
         return fail(stderr);
     }
-}
+};

--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -110,3 +110,9 @@ commonSpec.removeOutDir = function(filePath) {
     if(fs.existsSync(filePath))
         shelljs.rm('-rf', filePath);
 };
+
+commonSpec.detectNodeMessage = function(stderr) {
+    if (stderr.includes("node:")) {
+        return fail(stderr);
+    }
+}


### PR DESCRIPTION
:Release Notes:
Detect node warning in unit test

:Detailed Notes:
Add detecting code to detect node warnings through unit test

:Testing Performed:
1-1. Before CLI test, change settings
  - node v14.15.1
  - revert git to Update version 2.0.1(sha:519dd1836)
  - cherry-pick this commit on reverted git
1-2. Run unit test on below condition
  - failed test of ares-package/install/launch/inspect/server
2. Pass unit test on ose and auto
3. Pass eslint

:Issues Addressed:
[PLAT-131258] Implement node deprecated detect condition in TC