### PR TITLE
Fixed differences in ares-shell results

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -45,6 +45,7 @@ const async = require('async'),
                         execOption.pty = true;
                     }
 
+                    runCommand = "source /etc/profile;" + runCommand;
                     log.info("shell#remoteRun()", "cmd :", runCommand);
                     options.session.runWithOption(runCommand, execOption, process.stdin, process.stdout, process.stderr, next);
                 }

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -45,7 +45,7 @@ const async = require('async'),
                         execOption.pty = true;
                     }
 
-                    runCommand = "source /etc/profile;" + runCommand;
+                    runCommand = "source /etc/profile && " + runCommand;
                     log.info("shell#remoteRun()", "cmd :", runCommand);
                     options.session.runWithOption(runCommand, execOption, process.stdin, process.stdout, process.stderr, next);
                 }

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -109,3 +109,17 @@ describe(aresCmd + ' --run', function() {
         });
     });
 });
+
+describe(aresCmd + ' --run echo $PATH', function() {
+    it('Check environment variable with --run option', function(done) {
+        // eslint-disable-next-line no-useless-escape
+        exec(cmd + ' -r \'echo $PATH\'', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
+            expect(stdout.trim()).toBe("/usr/sbin:/usr/bin:/sbin:/bin", stderr);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
:Release Notes:
Fixed differences in ares-shell results

:Detailed Notes:
Fixed differences in ares-shell environment variable results
Whether in ssh's interactive mode, environment variable is different
Modified to ouput the same environment variable as through ares-shell

:Testing Performed:
1. Pass unit test on ose and auto
2. Pass eslint
3. Check if the results of the two commands below are the same
- ares-shell and then enter echo $PATH in connected shell
- ares-shell -r 'echo $PATH'
4. Check below command and result
- ares-shell -r "luna-send -n 1 -f luna://com.domain.app.service/hello '{}'"
  {
      "returnValue": true,
      "Response": "Hello, World!"
  }

:Issues Addressed:
[PLAT-134675] ares-shell's output is different from the actual results