### PR TITLE
:Release Notes:

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -30,8 +30,14 @@ const async = require('async'),
                     if (options && options.display) {
                         sessionLib.getSessionList(options, next);
                     } else {
-                        setImmediate(next);
+                        next();
                     }
+                },
+                function(next) {
+                    if (options && options.display && !options.sessionCall) {
+                        setImmediate(next, new Error("This device does not support the session."), {});
+                    }
+                    next();
                 },
                 function(next) {
                     if (options.sessionId) {
@@ -46,7 +52,7 @@ const async = require('async'),
                     }
 
                     log.info("shell#remoteRun()", "cmd :", runCommand);
-                    options.session.runWithOption(runCommand, {pty: true}, process.stdin, process.stdout, process.stderr, next);
+                    options.session.run(runCommand, process.stdin, process.stdout, process.stderr, next);
                 }
             ], function(err) {
                 setImmediate(next, err);
@@ -95,6 +101,7 @@ const async = require('async'),
                                 function  _printGuide() {
                                     process.stdout.write(">>> Start " + session.getDevice().name + " shell.\n");
                                     process.stdout.write(">>> Type `exit` to quit.\n\n");
+                                    // TO-DO: uncaughtException TypeError: process.stdin.setRawMode is not a function
                                     process.stdin.setRawMode(true);
                                 }
 
@@ -145,8 +152,14 @@ const async = require('async'),
                     if (options && options.display) {
                         sessionLib.getSessionList(options, next);
                     } else {
-                        setImmediate(next);
+                        next();
                     }
+                },
+                function(next) {
+                    if (options && options.display && !options.sessionCall) {
+                        setImmediate(next, new Error("This device does not support the session."), {});
+                    }
+                    next();
                 },
                 function(next) {
                     _ssh(options.session, next);

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -34,20 +34,19 @@ const async = require('async'),
                     }
                 },
                 function(next) {
-                    const execOption = {};
                     if (options.sessionId) {
                         if (options.session.getDevice().username !== 'root') {
                             return setImmediate(next, errHndl.changeErrMsg("NEED_ROOT_PERMISSION", "connect user session"));
                         }
 
                         // -l : make the shell a login shell, -c : command
-                        runCommand = `su ${options.sessionId} -l -c "${runCommand}"`;
-                        execOption.pty = true;
+                        runCommand = `su ${options.sessionId} -l -c '${runCommand}'`;
+                    } else {
+                        runCommand = "source /etc/profile && " + runCommand;
                     }
 
-                    runCommand = "source /etc/profile && " + runCommand;
                     log.info("shell#remoteRun()", "cmd :", runCommand);
-                    options.session.runWithOption(runCommand, execOption, process.stdin, process.stdout, process.stderr, next);
+                    options.session.runWithOption(runCommand, {pty: true}, process.stdin, process.stdout, process.stderr, next);
                 }
             ], function(err) {
                 setImmediate(next, err);

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -79,31 +79,34 @@ describe(aresCmd + ' --display(-dp)', function() {
         exec(cmd + ' -dp 1', function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-            }
-
-            if (options.device === "emulator") { // emulator's default setting user is "developer"
-                expect(stderr).toContain("Unable to connect to the target device. root access required <connect user session>", error);
-            }
-            else {
-                expect(stdout).toContain(`Start ${options.device} shell`, error);
+                // TO-DO: uncaughtException TypeError: process.stdin.setRawMode is not a function
+                // expect(stderr).toContain("This device does not support the session.");
+            } else {
+                if (options.device === "emulator") { // emulator's default setting user is "developer"
+                    expect(stderr).toContain("Unable to connect to the target device. root access required <connect user session>", error);
+                }
+                else {
+                    expect(stdout).toContain(`Start ${options.device} shell`, error);
+                }
             }
             done();
         });
     });
 });
 
-describe(aresCmd + ' --run', function() {
+describe(aresCmd + ' --run in session', function() {
     it('Run CMD', function(done) {
         // eslint-disable-next-line no-useless-escape
         exec(cmd + ' -dp 1 -r \"echo hello webOS\"', function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-            }
-
-            if (options.device === "emulator") { // emulator's default setting user is "developer"
-                expect(stderr).toContain("Unable to connect to the target device. root access required <connect user session>", error);
+                expect(stderr).toContain("This device does not support the session.");
             } else {
-                expect(stdout.trim()).toBe("hello webOS", stderr);
+                if (options.device === "emulator") { // emulator's default setting user is "developer"
+                    expect(stderr).toContain("Unable to connect to the target device. root access required <connect user session>", error);
+                } else {
+                    expect(stdout.trim()).toBe("hello webOS", stderr);
+                }
             }
             done();
         });
@@ -124,15 +127,16 @@ describe(aresCmd + ' --run echo $PATH', function() {
     });
 });
 
-describe(aresCmd + ' --run echo $PATH', function() {
+describe(aresCmd + ' --run echo $PATH in session', function() {
     it('Check environment variable with --run option', function(done) {
         // eslint-disable-next-line no-useless-escape
         exec(cmd + ' -dp 1 -r \'echo $PATH\'', function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
+                expect(stderr).toContain("This device does not support the session.");
+            } else {
+                expect(stdout.trim()).toBe("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", stderr);
             }
-
-            expect(stdout.trim()).toBe("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", stderr);
             done();
         });
     });

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -63,8 +63,8 @@ describe(aresCmd + ' --device-list(-D)', function() {
     });
 });
 
-describe('Check whether there is a session in the device', function() {
-    it('Session check', function(done) {
+describe('Check if there are sessions on the device', function() {
+    it('Check session', function(done) {
         const deviceCmd = common.makeCmd('ares-device');
         exec(deviceCmd + ` -s ${options.device}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -123,3 +123,17 @@ describe(aresCmd + ' --run echo $PATH', function() {
         });
     });
 });
+
+describe(aresCmd + ' --run echo $PATH', function() {
+    it('Check environment variable with --run option', function(done) {
+        // eslint-disable-next-line no-useless-escape
+        exec(cmd + ' -dp 1 -r \'echo $PATH\'', function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+
+            expect(stdout.trim()).toBe("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", stderr);
+            done();
+        });
+    });
+});

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -125,7 +125,7 @@ describe(aresCmd + ' --run in session', function() {
                     expect(stderr).toContain("This device does not support the session.");
                 }
             } else {
-                    expect(stdout.trim()).toBe("hello webOS", stderr);
+                expect(stdout.trim()).toBe("hello webOS", stderr);
             }
             done();
         });


### PR DESCRIPTION
Fixed differences in ares-shell results on session

:Detailed Notes:
Modified to ouput the same environment variable as through ares-shell on session

:Testing Performed:
1. Pass unit test on ose and auto
2. Pass eslint
3. Check results of below commands on auto device as root user and emulator as developer
- ares-shell.js -r "echo \$PATH"
- ares-shell.js -r 'echo $PATH'
- ares-shell.js -r 'echo $PATH' -dp 1
- ares-shell.js -r "echo \$PATH" -dp 1
- ares-shell.js -r "pwd"
- ares-shell.js -r "pwd" -dp 1
- ares-shell -r "luna-send -n 1 -f luna://com.domain.app.service/hello '{}'"
- ares-shell -r "luna-send -n 1 -f luna://com.domain.app.service/hello '{}'" -dp 1

:Issues Addressed:
[PLAT-135931] Support to output the same environment variable
              using ares-shell on auto session