### PR TITLE
Fix ares-device --capture bug on windows

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -329,8 +329,8 @@ const util = require('util'),
 
                 options.captureFormat = captureFormat;
                 options.captureFileName = captureFileName;
-                options.captureDirPath = "/tmp/aresCapture",
-                options.sourcePath = path.join(options.captureDirPath, captureFileName);
+                options.captureDirPath = "/tmp/aresCapture/";
+                options.sourcePath = options.captureDirPath + captureFileName;
                 options.destinationPath = destinationPath;
                 options.ignore = true;
                 options.silent = true;


### PR DESCRIPTION
:Release Notes:
Fix ares-device --capture bug on windows

:Detailed Notes:
In windows, an error stating that the path is invalid occurred.
So, this bug is fixed.

:Testing Performed:
1. Pass unit test on ose, auto and windows
2. Pass eslint
3. Verify with CLI commands
 - ares-device.js -c
 - ares-device.js -c -dp 1
 - ares-device.js -c webOSCap -dp 1
 - ares-device.js -c webOSCap/test1.bmp [or test1.jpg or test1.png]

:Issues Addressed:
[PLAT-138240] Fix bug of ares-device --capture on windows