### PR TITLE
Update unit test of ares-shell

### DIFF
--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -6,18 +6,15 @@
 
 /* eslint-disable no-useless-escape */
 const exec = require('child_process').exec,
-    os = require('os'),
     common = require('./common-spec');
 
 const aresCmd = 'ares-shell';
 
 let cmd,
     options,
-    hasSession = false,
-    osType;
+    hasSession = false;
 
 beforeAll(function (done) {
-    osType = os.type();
     cmd = common.makeCmd(aresCmd);
     common.getOptions()
     .then(function(result){
@@ -139,7 +136,7 @@ describe(aresCmd + ' --run in session', function() {
 describe(aresCmd + ' --run echo $PATH', function() {
     it('Check environment variable with --run option', function(done) {
         let tmpCmd = cmd + ' -r \"echo \\$PATH\"';
-        if (osType === "Windows_NT") {
+        if (process.platform === "win32") {
             tmpCmd = cmd + ' -r \"echo $PATH\"';
         }
 
@@ -157,7 +154,7 @@ describe(aresCmd + ' --run echo $PATH', function() {
 describe(aresCmd + ' --run echo $PATH in session', function() {
     it('Check environment variable with --run option', function(done) {
         let tmpCmd = cmd + ' -dp 1 -r \"echo \\$PATH\"';
-        if (osType === "Windows_NT") {
+        if (process.platform === "win32") {
             tmpCmd = cmd + ' -dp 1 -r \"echo $PATH\"';
         }
 

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 LG Electronics Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 
 /* eslint-disable no-useless-escape */
 const exec = require('child_process').exec,

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -1,7 +1,7 @@
 /*
-* Copyright (c) 2020 LG Electronics Inc.
-*
-* SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2020 LG Electronics Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
 */
 
 /* eslint-disable no-useless-escape */
@@ -142,7 +142,7 @@ describe(aresCmd + ' --run echo $PATH', function() {
         if (osType === "Windows_NT") {
             tmpCmd = cmd + ' -r \"echo $PATH\"';
         }
-        console.log(cmd);
+
         exec(tmpCmd, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
@@ -160,7 +160,7 @@ describe(aresCmd + ' --run echo $PATH in session', function() {
         if (osType === "Windows_NT") {
             tmpCmd = cmd + ' -dp 1 -r \"echo $PATH\"';
         }
-        console.log(tmpCmd);
+
         exec(tmpCmd, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -1,19 +1,23 @@
 /*
- * Copyright (c) 2020 LG Electronics Inc.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+* Copyright (c) 2020 LG Electronics Inc.
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
 
+/* eslint-disable no-useless-escape */
 const exec = require('child_process').exec,
+    os = require('os'),
     common = require('./common-spec');
 
 const aresCmd = 'ares-shell';
 
 let cmd,
     options,
-    hasSession = false;
+    hasSession = false,
+    osType;
 
 beforeAll(function (done) {
+    osType = os.type();
     cmd = common.makeCmd(aresCmd);
     common.getOptions()
     .then(function(result){
@@ -113,7 +117,6 @@ describe(aresCmd + ' --display(-dp)', function() {
 
 describe(aresCmd + ' --run in session', function() {
     it('Run CMD', function(done) {
-        // eslint-disable-next-line no-useless-escape
         exec(cmd + ' -dp 1 -r \"echo hello webOS\"', function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
@@ -132,10 +135,15 @@ describe(aresCmd + ' --run in session', function() {
     });
 });
 
+
 describe(aresCmd + ' --run echo $PATH', function() {
     it('Check environment variable with --run option', function(done) {
-        // eslint-disable-next-line no-useless-escape
-        exec(cmd + ' -r \'echo $PATH\'', function (error, stdout, stderr) {
+        let tmpCmd = cmd + ' -r \"echo \\$PATH\"';
+        if (osType === "Windows_NT") {
+            tmpCmd = cmd + ' -r \"echo $PATH\"';
+        }
+        console.log(cmd);
+        exec(tmpCmd, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
@@ -148,8 +156,12 @@ describe(aresCmd + ' --run echo $PATH', function() {
 
 describe(aresCmd + ' --run echo $PATH in session', function() {
     it('Check environment variable with --run option', function(done) {
-        // eslint-disable-next-line no-useless-escape
-        exec(cmd + ' -dp 1 -r \'echo $PATH\'', function (error, stdout, stderr) {
+        let tmpCmd = cmd + ' -dp 1 -r \"echo \\$PATH\"';
+        if (osType === "Windows_NT") {
+            tmpCmd = cmd + ' -dp 1 -r \"echo $PATH\"';
+        }
+        console.log(tmpCmd);
+        exec(tmpCmd, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
 


### PR DESCRIPTION
:Release Notes:
Update unit test of ares-shell

:Detailed Notes:
Since cmd processing is different between Windows and Linux,
the unit test is updated accordingly.

:Testing Performed:
1. Pass unit test on ose/auto and linux/windows
2. Pass eslint

:Issues Addressed:
[PLAT-138905] Update unit test of ares-shell