### PR TITLE
Constraint device name

### DIFF
--- a/bin/ares-setup-device.js
+++ b/bin/ares-setup-device.js
@@ -235,13 +235,13 @@ function _queryAddRemove(ssdpDevices, next) {
                 },
                 validate: function(input) {
                     if (input.length < 1) {
-                        return "Please enter device name.";
+                        return errHndl.changeErrMsg("EMPTY_VALUE", "DEVICE_NAME");
                     }
                     if (deviceNames.indexOf(input) !== -1) {
-                        return "Device name is duplicated. Please use another name.";
+                        return errHndl.changeErrMsg("EXISTING_VALUE", "DEVICE_NAME", input);
                     }
                     if (!isValidDeviceName(input)) {
-                        return "Invalid name. Please do not use letters starting with '%' or '$'.";
+                        return errHndl.changeErrMsg("INVALID_DEVICENAME");
                     }
                     return true;
                 }

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -34,7 +34,7 @@
         "INVALID_TEMPLATE" : "Invalid template name",
         "INVALID_FILE" : "Invalid file",
         "INVALID_VALUE" : "Invalid value",
-        "INVALID_DEVICENAME" : "Invalid device name. The device name should consist of letters, numbers, and special characters ('-','_','#') and should be start with letters or '_'",
+        "INVALID_DEVICENAME" : "Invalid device name. The device name should consist of letters, numbers, and special characters ('-','_','#') and should start with letters or '_'",
 
         "INVALID_OBJECT" : "Object format error",
         "INVALID_MODE" : "Please specify an option, either '--add' or '--modify'",

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -34,7 +34,7 @@
         "INVALID_TEMPLATE" : "Invalid template name",
         "INVALID_FILE" : "Invalid file",
         "INVALID_VALUE" : "Invalid value",
-        "INVALID_DEVICENAME" : "Invalid device name. Do not use letters starting with '%' or '$'",
+        "INVALID_DEVICENAME" : "Invalid device name. Please use letters, numbers and allowed characters ('-', '_', '#')",
         "INVALID_OBJECT" : "Object format error",
         "INVALID_MODE" : "Please specify an option, either '--add' or '--modify'",
         "INVALID_CAPTURE_FORMAT" : "Please specify file extension, either 'png' 'bmp' or 'jpg'",

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -34,7 +34,7 @@
         "INVALID_TEMPLATE" : "Invalid template name",
         "INVALID_FILE" : "Invalid file",
         "INVALID_VALUE" : "Invalid value",
-        "INVALID_DEVICENAME" : "Invalid device name. The device name should consist of letters, numbers, and special characters('-','_','#') and should be start with letters or '_'",
+        "INVALID_DEVICENAME" : "Invalid device name. The device name should consist of letters, numbers, and special characters ('-','_','#') and should be start with letters or '_'",
 
         "INVALID_OBJECT" : "Object format error",
         "INVALID_MODE" : "Please specify an option, either '--add' or '--modify'",

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -34,7 +34,8 @@
         "INVALID_TEMPLATE" : "Invalid template name",
         "INVALID_FILE" : "Invalid file",
         "INVALID_VALUE" : "Invalid value",
-        "INVALID_DEVICENAME" : "Invalid device name. Please use letters, numbers and allowed characters ('-', '_', '#')",
+        "INVALID_DEVICENAME" : "Invalid device name. The device name should consist of letters, numbers, and special characters('-','_','#') and should be start with letters or '_'",
+
         "INVALID_OBJECT" : "Object format error",
         "INVALID_MODE" : "Please specify an option, either '--add' or '--modify'",
         "INVALID_CAPTURE_FORMAT" : "Please specify file extension, either 'png' 'bmp' or 'jpg'",

--- a/lib/base/setup-device.js
+++ b/lib/base/setup-device.js
@@ -19,7 +19,8 @@ const async = require('async'),
     }
 
     function isValidDeviceName(name) {
-        return ['$', '%'].indexOf(name[0]) === -1;
+        const re = new RegExp("^[_a-zA-Z][a-zA-Z0-9#_-]*");
+        return (name === String(name.match(re)));
     }
 
     function isValidIpv4(host) {

--- a/spec/jsSpecs/ares-setup-device.spec.js
+++ b/spec/jsSpecs/ares-setup-device.spec.js
@@ -259,7 +259,6 @@ describe(aresCmd + ' negative TC ', function() {
         exec(cmd + ` -a ${deivceName}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-                console.log(stderr);
                 expect(stderr).toContain("Invalid device name. Please use letters, numbers and allowed characters ('-', '_', '#')");
             }
             done();

--- a/spec/jsSpecs/ares-setup-device.spec.js
+++ b/spec/jsSpecs/ares-setup-device.spec.js
@@ -212,6 +212,7 @@ describe(aresCmd + ' --search(-s), --timeout(-t)', function() {
         }, 2000);
     });
 });
+
 describe(aresCmd + ' --reset(-R)', function() {
     it('Add DEVICE', function(done) {
         const host = '192.168.0.5';
@@ -247,6 +248,20 @@ describe(aresCmd + ' --reset(-R)', function() {
             expect(stdout).toContain(initDevice.host);
             expect(stdout).toContain(initDevice.port);
             expect(stdout).toContain(initDevice.profile);
+            done();
+        });
+    });
+});
+
+describe(aresCmd + ' negative TC ', function() {
+    it('Add invalid DEVICE', function(done) {
+        const deivceName = "invalid#@!";
+        exec(cmd + ` -a ${deivceName}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                console.log(stderr);
+                expect(stderr).toContain("Invalid device name. Please use letters, numbers and allowed characters ('-', '_', '#')");
+            }
             done();
         });
     });

--- a/spec/jsSpecs/ares-setup-device.spec.js
+++ b/spec/jsSpecs/ares-setup-device.spec.js
@@ -259,7 +259,7 @@ describe(aresCmd + ' negative TC ', function() {
         exec(cmd + ` -a ${deivceName}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-                expect(stderr).toContain("Invalid device name. Please use letters, numbers and allowed characters ('-', '_', '#')");
+                expect(stderr).toContain("Invalid device name. The device name should consist of letters, numbers, and special characters");
             }
             done();
         });


### PR DESCRIPTION
:Release Notes:
Constrain device name on setup-device

:Detailed Notes:
Allow number, letter, -, _, # for adding device name
Add negative TC on setup-device spec file

:Testing Performed:
1. Unit test passed on OSE/Auto target
2. eslint passed.
3. Verified with CLI commands
- Add device name has "-, _, #" successfully
 `$ ./ares-setup-device.js -a auto_-#1` 
- Invalid device name can not be added. Print error message.
 `$ ./ares-setup-device.js -a invalid@`
   -> Invalid device name. Please use letters, numbers and allowed characters ('-', '_', '#')
 
:Issues Addressed:
[PLAT-137681] Add constraint for device name on ares-setup-device