### PR TITLE
Print default target device

### DIFF
--- a/bin/ares-package.js
+++ b/bin/ares-package.js
@@ -296,7 +296,7 @@ PalmPackage.prototype = {
                 if (err) {
                     return this.finish(err);
                 }
-                return this.finish(null, {msg: "no problems detected"});
+                return this.finish(null, {msg : "no problems detected"});
             }.bind(this));
     },
 

--- a/bin/ares-pull.js
+++ b/bin/ares-pull.js
@@ -110,7 +110,7 @@ function pull() {
         showUsage();
         cliControl.end(-1);
     }
-    pullLib.pull(options,finish);
+    pullLib.pull(options, finish);
 }
 
 function finish(err, value) {

--- a/bin/ares-shell.js
+++ b/bin/ares-shell.js
@@ -54,7 +54,7 @@ log.level = argv.level || 'warn';
 log.verbose("argv", argv);
 
 const options = {
-        name: argv.device,
+        device: argv.device,
         display : argv.display
     };
 

--- a/lib/base/novacom.js
+++ b/lib/base/novacom.js
@@ -14,7 +14,6 @@ const fs = require('fs'),
     log = require('npmlog'),
     Ssh2 = require('ssh2'),
     shelljs = require('shelljs'),
-    request = require('request'),
     server = require('./server'),
     errHndl = require('./error-handler'),
     Appdata = require('./cli-appdata');
@@ -323,6 +322,7 @@ const fs = require('fs'),
             if (devices.length < 1) {
                 setImmediate(next, errHndl.getErrMsg("UNMATCHED_DEVICE", key, value));
             } else {
+                console.log("Set target device to " +  value);
                 log.verbose("Resolver#getDeviceBy()", "devices:", devices);
                 if (typeof next === 'function') {
                     log.silly("Resolver#getDeviceBy()", "async");
@@ -332,48 +332,6 @@ const fs = require('fs'),
                     return devices[0];
                 }
             }
-        },
-
-        getSshPrvKey: function(target, next) {
-            const name = (typeof target === 'string') ? target : (target && target.name);
-            if (!name) {
-                setImmediate(next, errHndl.getErrMsg("EMPTY_VALUE", "DEVICE_NAME"));
-                return;
-            }
-
-            async.waterfall([
-                this.getDeviceBy.bind(this, 'name', name),
-                function(targetDevice, next) {
-                    log.info("Resolver#getSshPrvKey()", "targetDevice.host:", targetDevice.host);
-
-                    const url = 'http://' + targetDevice.host + ':9991' + '/webos_rsa',
-                        keyFileNamePrefix = targetDevice.name.replace(/(\s+)/gi, '_'),
-                        keyFileName = keyFileNamePrefix + "_webos",
-                        keySavePath = path.join(keydir, keyFileName);
-
-                    request.head(url, function(err, res) {
-                        if (err || (res && res.statusCode !== 200)) {
-                            return setImmediate(next, errHndl.getErrMsg("FAILED_GET_SSHKEY"));
-                        }
-
-                        log.info("Resolver#getSshPrvKey()#head", "content-type:", res.headers['content-type']);
-                        log.info("Resolver#getSshPrvKey()#head", "content-length:", res.headers['content-length']);
-                        request(url).pipe(fs.createWriteStream(keySavePath)).on('close', function() {
-                            if (err) {
-                                return setImmediate(next, errHndl.getErrMsg("FAILED_GET_SSHKEY"));
-                            } else {
-                                setImmediate(next, err, keySavePath, keyFileName);
-                            }
-                        });
-                    });
-                },
-                function(keyFilePath, keyFileName, next) {
-                    log.info("Resolver#getSshPrvKey()", "SSH Private Key:", keyFilePath);
-                    console.log("SSH Private Key:", keyFilePath);
-                    fs.chmodSync(keyFilePath, '0600');
-                    setImmediate(next, null, keyFileName);
-                }
-            ], next);
         },
 
         modifyDeviceFile: function(op, target, next) {

--- a/lib/device.js
+++ b/lib/device.js
@@ -55,7 +55,11 @@ const util = require('util'),
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _getOsInfo(next) {
@@ -211,7 +215,11 @@ const util = require('util'),
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _getSessionList(next) {
@@ -287,7 +295,11 @@ const util = require('util'),
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _makeCaptureOption(next) {

--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -91,7 +91,11 @@ let platformNodeVersion = "0";
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _runApp(next) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -72,14 +72,13 @@ const fs = require('fs'),
             async.waterfall([
                 function(next) {
                     options.nReplies = 0; // -i
-                    // eslint-disable-next-line no-new
-                    new novacom.Session(options.device, next);
+                    if(!options.session){
+                        options.session = new novacom.Session(options.device, next);
+                    } else {
+                        next(null, options.session);
+                    }
                 },
                 function(session, next) {
-                    options.session = session;
-                    setImmediate(next);
-                },
-                function(next) {
                     if (options.opkg) {
                         // FIXME: Need more consideration whether this condition is necessary or not.
                         if (options.session.getDevice().username !== 'root') {
@@ -253,11 +252,7 @@ const fs = require('fs'),
                     }
                 },
                 function(next) {
-                    options.session.end();
-                    options.session = null;
-                    next(null, {
-                        msg: "Success"
-                    });
+                    next(null, {msg: "Success"});
                 }
             ], function(err, result) {
                 log.verbose("installer#waterfall callback err:", err);
@@ -273,13 +268,16 @@ const fs = require('fs'),
             async.waterfall([
                 function(next) {
                     options.nReplies = undefined; // -i
-                    options.session = new novacom.Session(options.device, next);
+                    if(!options.session){
+                        options.session = new novacom.Session(options.device, next);
+                    } else {
+                        next(null, options.session);
+                    }
                 },
                 function(session, next) {
-                    options.session = session;
                     if (options.opkg) {
                         // FIXME: Need more consideration whether this condition is necessary or not.
-                        if (options.session.getDevice().username !== 'root') {
+                        if (session.getDevice().username !== 'root') {
                             return setImmediate(next, errHndl.getErrMsg("NEED_ROOT_PERMISSION","opkg remove"));
                         }
                     }
@@ -378,7 +376,11 @@ const fs = require('fs'),
             async.series([
                 function(next) {
                     options.nReplies = 1; // -n 1
-                    options.session = new novacom.Session(options.device, next);
+                    if(!options.session){
+                        options.session = new novacom.Session(options.device, next);
+                    } else {
+                        next();
+                    }
                 },
                 function(next) {
                     if (options.opkg) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -252,7 +252,7 @@ const fs = require('fs'),
                     }
                 },
                 function(next) {
-                    next(null, {msg: "Success"});
+                    next(null, {msg : "Success"});
                 }
             ], function(err, result) {
                 log.verbose("installer#waterfall callback err:", err);
@@ -277,7 +277,7 @@ const fs = require('fs'),
                 function(session, next) {
                     if (options.opkg) {
                         // FIXME: Need more consideration whether this condition is necessary or not.
-                        if (session.getDevice().username !== 'root') {
+                        if (options.session.getDevice().username !== 'root') {
                             return setImmediate(next, errHndl.getErrMsg("NEED_ROOT_PERMISSION","opkg remove"));
                         }
                     }

--- a/lib/launch.js
+++ b/lib/launch.js
@@ -101,7 +101,6 @@ const util = require('util'),
                 if (options.installMode === "Hosted" && !hostedAppInstalled) {
                     const hostedAppUrl = path.join(__dirname,hostedAppId + ".ipk");
                     options.appId = id;
-
                     installer.install(options, hostedAppUrl, next);
                 } else {
                     next();
@@ -110,7 +109,11 @@ const util = require('util'),
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _runAppServer(next){
@@ -242,7 +245,11 @@ const util = require('util'),
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _getSessionList(next) {
@@ -313,7 +320,11 @@ const util = require('util'),
 
             function _makeSession(next) {
                 options.nReplies = 1; // -n 1
-                options.session = new novacom.Session(options.device, next);
+                if (!options.session) {
+                    options.session = new novacom.Session(options.device, next);
+                } else {
+                    next();
+                }
             }
 
             function _getSessionList(next) {

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -55,8 +55,11 @@ const fs = require('fs'),
             };
 
             function _makeSession(next) {
-                // eslint-disable-next-line no-new
-                new novacom.Session(options.device, next);
+                if (options.session) {
+                    return next(null, options.session);
+                } else {
+                    options.session = new novacom.Session(options.device, next);
+                }
             }
 
             function _transferFiles(session, next) {

--- a/lib/pusher.js
+++ b/lib/pusher.js
@@ -51,12 +51,10 @@ const fs = require('fs'),
                 if (options.session) {
                     return next(null, options.session);
                 } else {
-                    // eslint-disable-next-line no-new
-                    new novacom.Session(options.device, next);
+                    options.session = new novacom.Session(options.device, next);
                 }
             },
             function(session, next) {
-                options.session = session;
                 getDestType(session, dstPath, function(err, type) {
                     curDstType = type;
                     if (!err && type === TYPE.FILE && srcPaths.length > 1) {

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -24,7 +24,11 @@ const async = require('async'),
             async.series([
                 function(next) {
                     options.nReplies = 1;
-                    options.session = new novacom.Session(options, next);
+                    if (!options.session) {
+                        options.session = new novacom.Session(options.device, next);
+                    } else {
+                        next();
+                    }
                 },
                 function(next) {
                     if (options && options.display) {
@@ -66,7 +70,7 @@ const async = require('async'),
                 async.series([
                     function(next) {
                         if (!session) {
-                            session = new novacom.Session(options, next);
+                            session = new novacom.Session(options.device, next);
                         } else {
                             setImmediate(next);
                         }
@@ -146,7 +150,11 @@ const async = require('async'),
             async.series([
                 function(next) {
                     options.nReplies = 1;
-                    options.session = new novacom.Session(options, next);
+                    if (!options.session) {
+                        options.session = new novacom.Session(options.device, next);
+                    } else {
+                        next();
+                    }
                 },
                 function(next) {
                     if (options && options.display) {

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -143,8 +143,6 @@ describe(aresCmd + ' --capture-screen(-c)', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
-            expect(stdout).not.toContain(options.device);
-            expect(stdout).not.toContain("display0");
             expect(stdout).toContain("screen.png");
             expect(stdout).toContain(path.resolve('.'));
 
@@ -159,7 +157,6 @@ describe(aresCmd + ' --capture-screen(-c)', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
-            expect(stdout).toContain(options.device);
             expect(stdout).toContain(new Date().getFullYear());
             expect(stdout).toContain("display1");
             expect(stdout).toContain(".png");
@@ -180,8 +177,6 @@ describe(aresCmd + ' --capture-screen(-c)', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
-            expect(stdout).not.toContain(options.device);
-            expect(stdout).not.toContain("display0");
             expect(stdout).toContain("screen.bmp");
             expect(stdout).toContain(captureDirPath);
             expect(fs.existsSync(captureDirPath)).toBe(true);
@@ -195,8 +190,6 @@ describe(aresCmd + ' --capture-screen(-c)', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
-            expect(stdout).not.toContain(options.device);
-            expect(stdout).not.toContain("display0");
             expect(stdout).toContain("screen.jpg");
             expect(stdout).toContain(captureDirPath);
             expect(fs.existsSync(captureDirPath)).toBe(true);

--- a/spec/jsSpecs/ares-inspect.spec.js
+++ b/spec/jsSpecs/ares-inspect.spec.js
@@ -80,24 +80,23 @@ describe(aresCmd, function() {
 describe(aresCmd, function() {
     it('Run web inspector for sample app', function(done) {
         const child = exec(cmd + ` -a ${options.pkgId} -dp 0`);
-        let result = "";
+        let stdoutData = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result += data;
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).toContain('Application Debugging - http://localhost');
+            expect(stdoutData).toContain('Application Debugging - http://localhost');
             done();
         }, 7000);
     });
@@ -119,24 +118,23 @@ describe(aresCmd, function() {
 describe(aresCmd +' --open(-o)', function() {
     it('Open web inspector for sample app', function(done) {
         const child = exec(cmd + ` -a ${options.pkgId} -o -dp 1`);
-        let result = "";
+        let stdoutData = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result += data;
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).toContain('Application Debugging - http://localhost');
+            expect(stdoutData).toContain('Application Debugging - http://localhost');
             done();
         }, 3000);
     });
@@ -156,42 +154,41 @@ describe(aresCmd +' --open(-o)', function() {
 });
 
 describe(aresCmd, function() {
-    let result = "";
+    let stdoutData = "";
 
     it('Run Node\'s Inspector for sample Service', function(done) {
         const child = exec(cmd + ` -s ${options.pkgService} -dp 1`);
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result += data;
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result += data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toContain("null");
-            expect(result).toContain("localhost");
+            expect(stdoutData).not.toContain("null");
+            expect(stdoutData).toContain("localhost");
             done();
         }, 10000);
     });
 });
 
 describe(aresCmd +' --open(-o)', function() {
-    let result = "";
+    let stdoutData = "";
 
     it('Open Node\'s Inspector for sample Service', function(done) {
         const child = exec(cmd + ` -s ${options.pkgService} -dp 0 -o`);
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result += data;
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
@@ -203,8 +200,8 @@ describe(aresCmd +' --open(-o)', function() {
 
         setTimeout(() => {
             child.kill();
-            expect(result).toContain("To debug your service, set \"localhost");
-            expect(result).toContain("Can not support \"--open option\" on platform node version 8 and later");
+            expect(stdoutData).toContain("To debug your service, set \"localhost");
+            expect(stdoutData).toContain("Can not support \"--open option\" on platform node version 8 and later");
             done();
         }, 7000);
     });

--- a/spec/jsSpecs/ares-inspect.spec.js
+++ b/spec/jsSpecs/ares-inspect.spec.js
@@ -80,12 +80,11 @@ describe(aresCmd, function() {
 describe(aresCmd, function() {
     it('Run web inspector for sample app', function(done) {
         const child = exec(cmd + ` -a ${options.pkgId} -dp 0`);
-        let result = null;
+        let result = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            expect(data).toContain('Application Debugging - http://localhost');
+            result += data;
         });
 
         child.stderr.on('data', function (data) {
@@ -98,7 +97,7 @@ describe(aresCmd, function() {
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(result).toContain('Application Debugging - http://localhost');
             done();
         }, 7000);
     });
@@ -112,7 +111,7 @@ describe(aresCmd, function() {
             expect(stdout).toContain(`Closed application ${options.pkgId}`, error);
             setTimeout(function(){
                 done();
-            },3000);
+            }, 3000);
         });
     });
 });
@@ -120,12 +119,11 @@ describe(aresCmd, function() {
 describe(aresCmd +' --open(-o)', function() {
     it('Open web inspector for sample app', function(done) {
         const child = exec(cmd + ` -a ${options.pkgId} -o -dp 1`);
-        let result = null;
+        let result = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            expect(data).toContain('Application Debugging - http://localhost');
+            result += data;
         });
 
         child.stderr.on('data', function (data) {
@@ -138,7 +136,7 @@ describe(aresCmd +' --open(-o)', function() {
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(result).toContain('Application Debugging - http://localhost');
             done();
         }, 3000);
     });
@@ -152,66 +150,61 @@ describe(aresCmd +' --open(-o)', function() {
             expect(stdout).toContain(`Closed application ${options.pkgId}`, error);
             setTimeout(function(){
                 done();
-            },3000);
+            }, 3000);
         });
     });
 });
 
 describe(aresCmd, function() {
-    let result = null;
+    let result = "";
 
     it('Run Node\'s Inspector for sample Service', function(done) {
         const child = exec(cmd + ` -s ${options.pkgService} -dp 1`);
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            expect(result).not.toContain("null");
-            expect(result).toContain("localhost");
+            result += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
+            result += data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(result).not.toContain("null");
+            expect(result).toContain("localhost");
             done();
         }, 10000);
     });
 });
 
 describe(aresCmd +' --open(-o)', function() {
-    let result = null;
+    let result = "";
 
     it('Open Node\'s Inspector for sample Service', function(done) {
         const child = exec(cmd + ` -s ${options.pkgService} -dp 0 -o`);
-        const guideTexts = ["To debug your service, set \"localhost",
-                            "Can not support \"--open option\" on platform node version 8 and later",
-                            "nodeInsptUrl" ];
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data.trim().replace(/\s+['\n']/g, '\n');
-            expect(result).not.toContain("null");
-            expect(guideTexts).toContain(String(result).split(":")[0]);
+            result += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
+            expect(result).toContain("To debug your service, set \"localhost");
+            expect(result).toContain("Can not support \"--open option\" on platform node version 8 and later");
             done();
         }, 7000);
     });

--- a/spec/jsSpecs/ares-install.spec.js
+++ b/spec/jsSpecs/ares-install.spec.js
@@ -80,6 +80,7 @@ describe(aresCmd + ' --list(-l)', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
+            expect(stdout).toContain(`Set target device to ${options.device}`);
             expect(stdout).toContain(options.pkgId, stderr);
             done();
         });

--- a/spec/jsSpecs/ares-launch.spec.js
+++ b/spec/jsSpecs/ares-launch.spec.js
@@ -232,26 +232,24 @@ describe(aresCmd +' --hosted(-H)', function() {
     });
 
     it('Launch -H SampleApp', function(done) {
-        let result = "";
+        let stdoutData = "";
         const child = exec(cmd + ` -H ${sampleAppPath}`);
         
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result += data;
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result += data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).toContain('Ares Hosted App is now running');
-            expect(result).not.toBeNull();
+            expect(stdoutData).toContain('Ares Hosted App is now running');
             done();
         }, 3000);
     });

--- a/spec/jsSpecs/ares-server.spec.js
+++ b/spec/jsSpecs/ares-server.spec.js
@@ -69,25 +69,23 @@ describe(aresCmd, function() {
 describe(aresCmd, function() {
     it('Run a local web server', function(done) {
         const child = exec(cmd + ` ${sampleAppPath}`);
-        let result;
+        let stdoutData = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            expect(data).toContain('Local server running on http://localhost');
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(stdoutData).toContain('Local server running on http://localhost');
             done();
         }, 3000);
     });
@@ -96,25 +94,23 @@ describe(aresCmd, function() {
 describe(aresCmd + ' --open(o)', function() {
     it('Run a local web server on browser ', function(done) {
         const child = exec(cmd + ` ${sampleAppPath} -o`);
-        let result;
+        let stdoutData = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            expect(data).toContain('Local server running on http://localhost');
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(stdoutData).toContain('Local server running on http://localhost');
             done();
         }, 3000);
     });
@@ -129,25 +125,23 @@ describe(aresCmd +' --port', function() {
     it('Set port for running web server', function(done) {
         const port = Math.floor((Math.random()*(50000 - 10000 + 1)) + 10000);
         const child = exec(cmd + ` -p ${port} ${sampleAppPath}`);
-        let result;
+        let stdoutData = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            expect(data).toContain(`Local server running on http://localhost:${port}`);
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(stdoutData).toContain(`Local server running on http://localhost:${port}`);
             done();
         }, 3000);
     });

--- a/spec/jsSpecs/ares-setup-device.spec.js
+++ b/spec/jsSpecs/ares-setup-device.spec.js
@@ -186,28 +186,23 @@ describe(aresCmd + ' --search(-s), --timeout(-t)', function() {
 
     it('Search webOS Devices', function(done) {
         const child = exec(cmd + ' -s -t 1');
-        let result;
+        let stdoutData = "";
 
         child.stdout.on('data', function (data) {
             process.stdout.write(data);
-            result = data;
-            if(!checkDone) {
-                expect(data).toContain("Searching...");
-                checkDone = true;
-            }
+            stdoutData += data;
         });
 
         child.stderr.on('data', function (data) {
             if (data && data.length > 0) {
                 common.detectNodeMessage(data);
             }
-            result = data;
             expect(data).toBeNull();
         });
 
         setTimeout(() => {
             child.kill();
-            expect(result).not.toBeNull();
+            expect(stdoutData).toContain("Searching...");
             done();
         }, 2000);
     });

--- a/spec/jsSpecs/ares-shell.spec.js
+++ b/spec/jsSpecs/ares-shell.spec.js
@@ -123,7 +123,7 @@ describe(aresCmd + ' --run in session', function() {
                     expect(stderr).toContain("ares-shell ERR! [Tips]: This device does not support multiple sessions");
                 }
             } else {
-                expect(stdout.trim()).toBe("hello webOS", stderr);
+                expect(stdout.trim()).toContain("hello webOS", stderr);
             }
             done();
         });
@@ -142,7 +142,7 @@ describe(aresCmd + ' --run echo $PATH', function() {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
-            expect(stdout.trim()).toBe("/usr/sbin:/usr/bin:/sbin:/bin", stderr);
+            expect(stdout.trim()).toContain("/usr/sbin:/usr/bin:/sbin:/bin", stderr);
             done();
         });
     });
@@ -165,7 +165,7 @@ describe(aresCmd + ' --run echo $PATH in session', function() {
                     expect(stderr).toContain("ares-shell ERR! [Tips]: This device does not support multiple sessions");
                 }
             } else {
-                expect(stdout.trim()).toBe("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", stderr);
+                expect(stdout.trim()).toContain("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", stderr);
             }
             done();
         });


### PR DESCRIPTION
:Release Notes:
Avoid multiple session connections in CLI

:Detailed Notes:
- Fix multiple ssh connection
- Change ares-shell's internal option name to device
- Remove unused code
- Update TC

:Testing Performed:
1. Passed unit test ose & auto target
2. Passed eslint
3. Verified with CLI commands 
a. `$killall node`
b. Check ssh connection using `$ss |grep ssh` . It shows no list.
c. Install com.jasmine.web.app in CLI TC
d. `$ares-inspect.js -s com.jasmine.web.app.service` 
e. `$ss |grep ssh` shows only one ssh connection.
f. Press Ctrl+C to exit ares-shell.
g. `$ss |grep ssh` shows no list.

:Issues Addressed:
[PLAT-137688] Avoid multiple ssh connections in CLI