### PR TITLE
Improve applist

### DIFF
--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -152,9 +152,9 @@ function list(){
         if (pkgs instanceof Array) pkgs.forEach(function (pkg) {
             if (!argv.type || (argv.type && (argv.type === pkg.type))) {
                 if (cnt++ !== 0) {
-                    strPkgs = strPkgs.concat('\n');
+                    strPkgs += '\n';
                 }
-                strPkgs = strPkgs.concat(pkg.id);
+                strPkgs += pkg.id;
             }
         });
         finish(err, {msg : strPkgs.trim()});
@@ -165,9 +165,9 @@ function listFull() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
         for (let index = 0; index < pkgs.length; index++) {
-            strPkgs = strPkgs.concat("id : "+ pkgs[index].id, '\n');
+            strPkgs += "id : "+ pkgs[index].id + '\n';
             delete pkgs[index].id;
-            strPkgs = strPkgs.concat(convertJsonToList(pkgs[index], 0), '\n');
+            strPkgs += convertJsonToList(pkgs[index], 0) + '\n';
         }
         finish(err, {msg : strPkgs.trim()});
     });

--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -165,8 +165,9 @@ function listFull() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
         for (let index = 0; index < pkgs.length; index++) {
-            strPkgs += convertJsonToList(pkgs[index], 0);
-            strPkgs = strPkgs.concat('\n');
+            strPkgs = strPkgs.concat("id : "+ pkgs[index].id, '\n');
+            delete pkgs[index].id;
+            strPkgs = strPkgs.concat(convertJsonToList(pkgs[index], 0), '\n');
         }
         finish(err, {msg : strPkgs.trim()});
     });

--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -148,14 +148,16 @@ function install() {
 function list(){
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
-        if (Array.isArray(pkgs)) pkgs.forEach(function (pkg) {
-            if (argv.type) {
-                if (argv.type !== pkg.type) {
-                    return;
+        if (Array.isArray(pkgs)) {
+            pkgs.forEach(function (pkg) {
+                if (argv.type) {
+                    if (argv.type !== pkg.type) {
+                        return;
+                    }
                 }
-            }
-            strPkgs += pkg.id + '\n';
-        });
+                strPkgs += pkg.id + '\n';
+            });
+        }
         finish(err, {msg : strPkgs.trim()});
     });
 }
@@ -163,11 +165,13 @@ function list(){
 function listFull() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
-        if (Array.isArray(pkgs)) pkgs.forEach(function (pkg) {
-            strPkgs += "id : "+ pkg.id + '\n';
-            delete pkg.id;
-            strPkgs += convertJsonToList(pkg, 0) + '\n';
-        });
+        if (Array.isArray(pkgs)) {
+            pkgs.forEach(function (pkg) {
+                strPkgs += "id : "+ pkg.id + '\n';
+                delete pkg.id;
+                strPkgs += convertJsonToList(pkg, 0) + '\n';
+            });
+        }
         finish(err, {msg : strPkgs.trim()});
     });
 }

--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -148,13 +148,9 @@ function install() {
 function list(){
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
-        let cnt = 0;
         if (pkgs instanceof Array) pkgs.forEach(function (pkg) {
             if (!argv.type || (argv.type && (argv.type === pkg.type))) {
-                if (cnt++ !== 0) {
-                    strPkgs += '\n';
-                }
-                strPkgs += pkg.id;
+                strPkgs += pkg.id + '\n';
             }
         });
         finish(err, {msg : strPkgs.trim()});

--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -148,10 +148,13 @@ function install() {
 function list(){
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
-        if (pkgs instanceof Array) pkgs.forEach(function (pkg) {
-            if (!argv.type || (argv.type && (argv.type === pkg.type))) {
-                strPkgs += pkg.id + '\n';
+        if (Array.isArray(pkgs)) pkgs.forEach(function (pkg) {
+            if (argv.type) {
+                if (argv.type !== pkg.type) {
+                    return;
+                }
             }
+            strPkgs += pkg.id + '\n';
         });
         finish(err, {msg : strPkgs.trim()});
     });
@@ -160,11 +163,11 @@ function list(){
 function listFull() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
-        for (let index = 0; index < pkgs.length; index++) {
-            strPkgs += "id : "+ pkgs[index].id + '\n';
-            delete pkgs[index].id;
-            strPkgs += convertJsonToList(pkgs[index], 0) + '\n';
-        }
+        if (Array.isArray(pkgs)) pkgs.forEach(function (pkg) {
+            strPkgs += "id : "+ pkg.id + '\n';
+            delete pkg.id;
+            strPkgs += convertJsonToList(pkg, 0) + '\n';
+        });
         finish(err, {msg : strPkgs.trim()});
     });
 }

--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -12,7 +12,8 @@ const fs = require('fs'),
     log = require('npmlog'),
     nopt = require('nopt'),
     installLib = require('./../lib/install'),
-    commonTools = require('./../lib/base/common-tools');
+    commonTools = require('./../lib/base/common-tools'),
+    convertJsonToList = require('./../lib/util/json').convertJsonToList;
 
 const processName = path.basename(process.argv[1]).replace(/.js/, '');
 
@@ -92,7 +93,7 @@ const options = {
         appId: 'com.ares.defaultName',
         device: argv.device,
         opkg: argv.opkg || false,
-        opkg_param:  argv['opkg-param'],
+        opkg_param:  argv['opkg-param']
     };
 
 let op;
@@ -149,38 +150,25 @@ function list(){
         let strPkgs = "";
         let cnt = 0;
         if (pkgs instanceof Array) pkgs.forEach(function (pkg) {
-            if (argv.type) {
-                if (argv.type !== pkg.type) {
-                    return;
+            if (!argv.type || (argv.type && (argv.type === pkg.type))) {
+                if (cnt++ !== 0) {
+                    strPkgs = strPkgs.concat('\n');
                 }
+                strPkgs = strPkgs.concat(pkg.id);
             }
-            if (cnt++ !== 0) strPkgs = strPkgs.concat('\n');
-            strPkgs = strPkgs.concat(pkg.id);
         });
-        console.log(strPkgs);
-        finish(err);
+        finish(err, {msg : strPkgs.trim()});
     });
 }
 
 function listFull() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
-        if (pkgs instanceof Array) pkgs.forEach(function (pkg) {
-            if (argv.type) {
-                if (argv.type !== pkg.type) {
-                    return;
-                }
-            }
-            strPkgs = strPkgs.concat('----------------\n');
-            strPkgs = strPkgs.concat("id:"+ pkg.id+", ");
-            for (const key in pkg) {
-                if (key === "id") continue;
-                strPkgs = strPkgs.concat(key+":").concat(pkg[key]).concat(", ");
-            }
+        for (let index = 0; index < pkgs.length; index++) {
+            strPkgs += convertJsonToList(pkgs[index], 0);
             strPkgs = strPkgs.concat('\n');
-        });
-        process.stdout.write(strPkgs);
-        finish(err);
+        }
+        finish(err, {msg : strPkgs.trim()});
     });
 }
 

--- a/bin/ares-package.js
+++ b/bin/ares-package.js
@@ -296,7 +296,7 @@ PalmPackage.prototype = {
                 if (err) {
                     return this.finish(err);
                 }
-                return this.finish(null, {msg: "no problems detected"});
+                return this.finish(null, {msg : "no problems detected"});
             }.bind(this));
     },
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -201,8 +201,7 @@ const util = require('util'),
                 if (results[1] !== undefined) {
                     if (typeof results[1] === "object") {
                         for (let i = 0; i < results[1].length; i++) {
-                            resultTxt += convertJsonToList(results[1][i], 0);
-                            resultTxt = resultTxt.concat('\n');
+                            resultTxt += convertJsonToList(results[1][i], 0) + '\n';
                         }
                     } else {
                         resultTxt = results[1];

--- a/lib/device.js
+++ b/lib/device.js
@@ -14,7 +14,8 @@ const util = require('util'),
     luna = require('./base/luna'),
     novacom = require('./base/novacom'),
     errHndl = require('./base/error-handler'),
-    pullLib = require('./pull');
+    pullLib = require('./pull'),
+    convertJsonToList = require('./../lib/util/json').convertJsonToList;
 
 (function() {
 
@@ -200,7 +201,8 @@ const util = require('util'),
                 if (results[1] !== undefined) {
                     if (typeof results[1] === "object") {
                         for (let i = 0; i < results[1].length; i++) {
-                            resultTxt += _makeReturnTxt(results[1][i], 0) + "\n";
+                            resultTxt += convertJsonToList(results[1][i], 0);
+                            resultTxt = resultTxt.concat('\n');
                         }
                     } else {
                         resultTxt = results[1];
@@ -233,27 +235,6 @@ const util = require('util'),
                         log.verbose("device#sessionInfo#_getSessionList():", "failure" + lineObj.errorText);
                     }
                 }, next);
-            }
-
-            function _makeReturnTxt(resultValue, cnt){
-                log.info("device#sessionInfo#_makeReturnTxt()");
-                let returnTxt = "", prefix;
-                for (const key in resultValue) {
-                    prefix = "";
-                    if (typeof resultValue[key] === "object") {
-                        for (let i = 0; i < cnt; i++) {
-                            prefix += "-";
-                        }
-                        returnTxt += prefix + key + "\n" + _makeReturnTxt(resultValue[key], cnt + 1);
-                        continue;
-                    }
-
-                    for (let i = 0; i < cnt; i++) {
-                        prefix += "-";
-                    }
-                    returnTxt += prefix + key + " : " + resultValue[key] + "\n";
-                }
-                return returnTxt;
             }
         },
         /**

--- a/lib/util/json.js
+++ b/lib/util/json.js
@@ -43,7 +43,7 @@ function convertJsonToList(orgJson, level){
         return returnText += prefix + orgJson + "\n";
     } else if (Array.isArray(orgJson) && orgJson.length > 0) {
         for (let index = 0; index < orgJson.length; index++) {
-            returnText += convertJsonToList(orgJson[index], level + 1);
+            returnText += convertJsonToList(orgJson[index], level);
         }
     } else {
         // handle object type

--- a/lib/util/json.js
+++ b/lib/util/json.js
@@ -32,5 +32,32 @@ function readJsonAsync(file) {
         });
 }
 
+function convertJsonToList(orgJson, level){
+    let returnText = "", prefix = "";
+
+    for (let i = 0; i < level; i++) {
+        prefix += "-";
+    }
+
+    if(typeof orgJson === "string") {
+        return returnText += prefix + orgJson + "\n";
+    } else if (Array.isArray(orgJson) && orgJson.length > 0) {
+        for (let index = 0; index < orgJson.length; index++) {
+            returnText += convertJsonToList(orgJson[index], level + 1);
+        }
+    } else {
+        // handle object type
+        for (const key in orgJson) {
+            if (typeof orgJson[key] === "object") {
+                returnText += prefix + key + "\n" +  convertJsonToList(orgJson[key], level + 1);
+            } else {
+                returnText += prefix + key + " : " + orgJson[key] + "\n";
+            }
+        }
+    }
+    return returnText;
+}
+
 module.exports.readJsonSync = readJsonSync;
 module.exports.readJsonAsync = readJsonAsync;
+module.exports.convertJsonToList = convertJsonToList;

--- a/lib/util/json.js
+++ b/lib/util/json.js
@@ -40,7 +40,7 @@ function convertJsonToList(orgJson, level){
     }
 
     if(typeof orgJson === "string") {
-        return returnText += prefix + orgJson + "\n";
+        return returnText += prefix + orgJson + '\n';
     } else if (Array.isArray(orgJson) && orgJson.length > 0) {
         for (let index = 0; index < orgJson.length; index++) {
             returnText += convertJsonToList(orgJson[index], level);
@@ -49,9 +49,9 @@ function convertJsonToList(orgJson, level){
         // handle object type
         for (const key in orgJson) {
             if (typeof orgJson[key] === "object") {
-                returnText += prefix + key + "\n" +  convertJsonToList(orgJson[key], level + 1);
+                returnText += prefix + key + '\n' +  convertJsonToList(orgJson[key], level + 1);
             } else {
-                returnText += prefix + key + " : " + orgJson[key] + "\n";
+                returnText += prefix + key + " : " + orgJson[key] + '\n';
             }
         }
     }

--- a/spec/jsSpecs/ares-install.spec.js
+++ b/spec/jsSpecs/ares-install.spec.js
@@ -93,7 +93,7 @@ describe(aresCmd + ' --listfull(-F)', function() {
                 common.detectNodeMessage(stderr);
             }
             expect(stdout).toContain(options.pkgId, stderr);
-            expect(stdout).toContain("version:0.0.1");
+            expect(stdout).toContain("version : 0.0.1");
             done();
         });
     });


### PR DESCRIPTION
Make ares-install -F result more readable

:Release Notes:
Make ares-install -F result more readable

:Detailed Notes:
Current result of ares-install -F is hard to read
Show app's detail infomation as ares-device -s option

:Testing Performed:
1. Passed Unit test in OSE & Auto target
2. Passed eslint
3. Verified with CLI commands
  a. Install apps using ares-install
  b. $ ares-install -F
     id : com.domain.app
     transparent : false
    ... 
  c. Check "$ares-install -l" shows correct list
  d. Check "$ares-device -s" on Auto. Check the result format 

:Issues Addressed:
[PLAT-134674] Make ares-install -F result more readable