### PR TITLE
Apply error heading to ares-server

### DIFF
--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -37,7 +37,7 @@ const log = require('npmlog');
             "ERR_INVALID_DISPLAY" : "Please use a valid value for display id",
 
             "EACCES" : "No permission to execute. Please check the directory permission",
-            "EADDRINUSE" : "An attempt to bind a server to a local address failed. Please check the IP address or the port number",
+            "EADDRINUSE" : "An attempt to bind a server to the port failed. Please check the port number",
             "ECONNREFUSED": "Connection refused. Please check the device IP address or the port number",
             "ECONNRESET": "Unable to connect to the device. Please check the device",
             "ENOENT": "Please check if the path is valid",

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -37,6 +37,7 @@ const log = require('npmlog');
             "ERR_INVALID_DISPLAY" : "Please use a valid value for display id",
 
             "EACCES" : "No permission to execute. Please check the directory permission",
+            "EADDRINUSE" : "An attempt to bind a server to a local address failed. Please check the IP address or the port number",
             "ECONNREFUSED": "Connection refused. Please check the device IP address or the port number",
             "ECONNRESET": "Unable to connect to the device. Please check the device",
             "ENOENT": "Please check if the path is valid",

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -37,7 +37,7 @@ const log = require('npmlog');
             "ERR_INVALID_DISPLAY" : "Please use a valid value for display id",
 
             "EACCES" : "No permission to execute. Please check the directory permission",
-            "EADDRINUSE" : "An attempt to bind a server to the port failed. Please check the port number",
+            "EADDRINUSE" : "An attempt to bind a server to a local address failed. Please check the IP address or the port number",
             "ECONNREFUSED": "Connection refused. Please check the device IP address or the port number",
             "ECONNRESET": "Unable to connect to the device. Please check the device",
             "ENOENT": "Please check if the path is valid",

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -8,7 +8,8 @@ const fs = require('fs'),
     Express = require('express'),
     http = require('http'),
     bodyParser = require('body-parser'),
-    spawn = require('child_process').spawn;
+    spawn = require('child_process').spawn,
+    errHndl = require('./error-handler');
 
 (function () {
     const platformOpen = {
@@ -47,9 +48,13 @@ const fs = require('fs'),
         }
 
         const localServer = http.createServer(app);
+
+        localServer.on('error', function(err) {
+            return next(errHndl.getErrMsg(err));
+        });
         localServer.listen(port, function(err) {
             if (err) {
-                return next(new Error(err));
+                return next(errHndl.getErrMsg(err));
             }
             const localServerPort = localServer.address().port,
                 url = 'http://localhost:' + localServerPort;

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -48,7 +48,6 @@ const fs = require('fs'),
         }
 
         const localServer = http.createServer(app);
-
         localServer.on('error', function(err) {
             return next(errHndl.getErrMsg(err));
         });

--- a/lib/device.js
+++ b/lib/device.js
@@ -127,7 +127,7 @@ const util = require('util'),
                     return next(null, "chromium_version : " + "not supported");
                 } else {
                     const cmd = '/usr/bin/opkg list-installed webruntime';
-                    options.session.run(cmd, null, __data, __error, function(err) {
+                    options.session.run(cmd, null, __data, null, function(err) {
                         if (err) {
                             return next(err);
                         }
@@ -140,11 +140,6 @@ const util = require('util'),
 
                     next(null, "chromium_version : " + version);
                 }
-
-                function __error(data) {
-                    const str = (Buffer.isBuffer(data)) ? data.toString() : data;
-                    return next(new Error(str));
-                }
             }
 
             function _getQtbaseVersion(next) {
@@ -155,7 +150,7 @@ const util = require('util'),
                     return next(null, "qt_version : " + "not supported");
                 } else {
                     const cmd = '/usr/bin/opkg list-installed qtbase';
-                    options.session.run(cmd, null, __data, __error,  function(err) {
+                    options.session.run(cmd, null, __data, null, function(err) {
                         if (err) {
                             return next(err);
                     }});
@@ -165,11 +160,6 @@ const util = require('util'),
                         exp = /\d*\.\d*\.\d*/,
                         version = str.match(exp);
                     next(null, "qt_version : " + version);
-                }
-
-                function __error(data) {
-                    const str = (Buffer.isBuffer(data)) ? data.toString() : data;
-                    return next(new Error(str));
                 }
             }
 


### PR DESCRIPTION
:Release Notes:
Apply error heading to ares-server

:Detailed Notes:
- When ares-server --port executed with already used port
the error message is printed with "uncaughtException"
- Apply error heading to ares-server error
- Remove unused error handing in ares-device -i option

:Testing Performed:
1. Passed unit test ose & auto target
2. Passed eslint
3. Verified with CLI commands
    - Open 1st terminal and execute ares-sever with --port option
     $ ./ares-server.js --port 12345 sampleWebApp
    - Open 2nd terminal and execute the same command
      $ ./ares-server.js --port 12345 sampleWebApp
        ares-server ERR! [syscall failure]: listen EADDRINUSE: address already in use :::12345
        ares-server ERR! [Tips]: An attempt to bind a server to a local address failed. Please check the IP address or the port number
     - Execute ./ares-device.js -i on emulator with developer user.
       chromium_version and qt_version should be "not supported"

:Issues Addressed:
[PLAT-142770] Update system TC related to error mesage and capture