### PR TITLE
Support output format in file option on ares-log

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -130,6 +130,9 @@ const util = require('util'),
 
                 if (options.argv.file) {
                     options.cmd = "journalctl --file /run/log/journal/" + options.logDir + "/" + options.argv.file;
+                    if (options.argv.output) {
+                        options.cmd += " --output " + options.argv.argv.remain;
+                    }
                 }
 
                 if (options.argv['file-list']) {

--- a/spec/jsSpecs/ares-log.spec.js
+++ b/spec/jsSpecs/ares-log.spec.js
@@ -163,6 +163,20 @@ describe(aresCmd + " --file", function() {
             done();
         });
     });
+
+    it("Show log with --file and --output option", function(done) {
+        exec(cmd + " --file system.journal --output json", function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                if (options.device === "emulator") {
+                    expect(stderr).toContain("ares-log ERR! [Tips]: Unable to connect to the target device. root access required");
+                }
+            } else {
+                expect(typeof JSON.parse(stdout.split("\n")[0])).toBe('object');
+            }
+            done();
+        });
+    });
 });
 
 describe(aresCmd + " -ul", function() {


### PR DESCRIPTION
:Release Notes:
Support output format in file option on ares-log

:Detailed Notes:
- Modify output option is applied to file option on ares-log
- Update unit test case

:Testing Performed:
1. Pass unit test on ose and auto
2. Pass eslint
3. Check below command and output format
 - ares-log --file system.journal --output json

:Issues Addressed:
[PLAT-142907] Support output format in file option on ares-log