### PR TITLE
Support to save file in follow option on ares-log

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -43,7 +43,11 @@ const util = require('util'),
                     options.session.run(options.cmd, process.stdin, _onData, process.stderr, next);
                 },
             ],  function(err) {
-                next(err, null);
+                if (options.argv.save) {
+                    next(err, {msg : "\nCreated " + options.argv.argv.remain[0] +"\nSuccess"});
+                } else {
+                    next(err, null);
+                }
             });
 
             function _getSession(next) {
@@ -68,7 +72,6 @@ const util = require('util'),
 
                 if (options.argv.save) {
                     fs.writeFileSync(options.argv.argv.remain[0], data, {encoding: 'utf8', flag:'a'});
-                    next(null, {msg : "\nCreated " + options.argv.argv.remain[0] +"\nSuccess"});
                 }
             }
 
@@ -107,7 +110,11 @@ const util = require('util'),
                     options.session.run(options.cmd, process.stdin, _onData, process.stderr, next);
                 },
             ],  function(err) {
-                next(err, null);
+                if (options.argv.save) {
+                    next(err, {msg : "\nCreated " + options.argv.argv.remain[0] +"\nSuccess"});
+                } else {
+                    next(err, null);
+                }
             });
 
             function _getLogDir(next) {
@@ -159,7 +166,6 @@ const util = require('util'),
 
                 if (options.argv.save) {
                     fs.writeFileSync(options.argv.argv.remain[0], data, {encoding: 'utf8', flag:'a'});
-                    next(null, {msg : "\nCreated " + options.argv.argv.remain[0] +"\nSuccess"});
                 }
             }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -44,7 +44,7 @@ const util = require('util'),
                 },
             ],  function(err) {
                 if (options.argv.save) {
-                    next(err, {msg : "\nCreated " + options.argv.argv.remain[0] +"\nSuccess"});
+                    next(err, {msg : "\nCreated " + options.argv.argv.remain[0] + "\nSuccess"});
                 } else {
                     next(err, null);
                 }
@@ -111,7 +111,7 @@ const util = require('util'),
                 },
             ],  function(err) {
                 if (options.argv.save) {
-                    next(err, {msg : "\nCreated " + options.argv.argv.remain[0] +"\nSuccess"});
+                    next(err, {msg : "\nCreated " + options.argv.argv.remain[0] + "\nSuccess"});
                 } else {
                     next(err, null);
                 }


### PR DESCRIPTION
Support to save file in follow option on ares-log

:Detailed Notes:
Modify to support both save and follow options at same time

:Testing Performed:
1. Pass unit test on ose and auto emulator
2. Pass eslint
3. Check below command
  - ares-log -f -s saved.log

:Issues Addressed:
[PLAT-143147] Support to save file in follow option on ares-log