### PR TITLE
Change ares-command -v to consistent behavior

### DIFF
--- a/bin/ares-config.js
+++ b/bin/ares-config.js
@@ -55,6 +55,23 @@ log.heading = processName;
 log.level = argv.level || 'warn';
 log.verbose("argv", argv);
 
+/**
+ * For consistent of "$command -v", argv is used.
+ * By nopt, argv is parsed and set key-value in argv object.
+ * If -v or --level option is input with command, it is set key-value in argv.
+ * After it is deleted, If remained key is only one in argv object
+ * (If any other are remained, it's mean another options is input)
+ * and there is no remaining after parsing the input command by nopt
+ * (If any other are remained, it's mean another parameters ares input),
+ * each command of webOS CLI print help message with log message.
+ */
+if (argv.level) {
+    delete argv.level;
+    if (argv.argv.remain.length === 0 && (Object.keys(argv)).length === 1) {
+        argv.help = true;
+    }
+}
+
 const options = {
     profile: argv.profile
 };

--- a/bin/ares-log.js
+++ b/bin/ares-log.js
@@ -98,6 +98,23 @@ log.heading = processName;
 log.level = argv.level || 'warn';
 log.verbose("argv", argv);
 
+/**
+ * For consistent of "$command -v", argv is used.
+ * By nopt, argv is parsed and set key-value in argv object.
+ * If -v or --level option is input with command, it is set key-value in argv.
+ * After it is deleted, If remained key is only one in argv object
+ * (If any other are remained, it's mean another options is input)
+ * and there is no remaining after parsing the input command by nopt
+ * (If any other are remained, it's mean another parameters ares input),
+ * each command of webOS CLI print help message with log message.
+ */
+if (argv.level) {
+    delete argv.level;
+    if (argv.argv.remain.length === 0 && (Object.keys(argv)).length === 1) {
+        argv.help = true;
+    }
+}
+
 const options = {
     device: argv.device,
     display: argv.display,

--- a/bin/ares.js
+++ b/bin/ares.js
@@ -51,6 +51,23 @@ log.heading = processName;
 log.level = argv.level || 'warn';
 log.verbose("argv", argv);
 
+/**
+ * For consistent of "$command -v", argv is used.
+ * By nopt, argv is parsed and set key-value in argv object.
+ * If -v or --level option is input with command, it is set key-value in argv.
+ * After it is deleted, If remained key is only one in argv object
+ * (If any other are remained, it's mean another options is input)
+ * and there is no remaining after parsing the input command by nopt
+ * (If any other are remained, it's mean another parameters ares input),
+ * each command of webOS CLI print help message with log message.
+ */
+if (argv.level) {
+    delete argv.level;
+    if (argv.argv.remain.length === 0 && (Object.keys(argv)).length === 1) {
+        argv.help = true;
+    }
+}
+
 let op;
 if (argv.list) {
     op = commandList;


### PR DESCRIPTION
:Release Notes:
Change ares-command -v to consistent behavior

:Detailed Notes:
ares, ares-config and ares-log -v option are behaved differently.
So, changed them to consistent behavior.

:Testing Performed:
1. Pass unit test on ose and auto
2. Pass eslint
3. Check below command and printed help message with verbose log
  - ares -v
  - ares-config -v
  - ares-log -v

:Issues Addressed:
[PLAT-143017] Change ares-command -v to consistent behavior