### PR TITLE
Add empty session tips for Auto

### DIFF
--- a/bin/ares-launch.js
+++ b/bin/ares-launch.js
@@ -208,6 +208,10 @@ function running() {
     launchLib.listRunningApp(options, function(err, runningApps) {
         let strRunApps = "";
         let cnt = 0;
+
+        if (err) {
+            return finish(err);
+        }
         if (runningApps instanceof Array) runningApps.forEach(function (runApp) {
             if (cnt++ !== 0) {
                 strRunApps = strRunApps.concat('\n');
@@ -217,8 +221,7 @@ function running() {
                 strRunApps += " - display " + runApp.displayId;
             }
         });
-        console.log(strRunApps);
-        finish(err);
+        finish(null, {msg : strRunApps});
     });
 }
 

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -13,7 +13,7 @@ const log = require('npmlog');
             "for category \"/dev\"" : "Please enable \"Developer options\" on your device",
 
             // sessionmanager
-            "ENABLE_PROFILE" : "Please select \"Profile icon\" on display",
+            "SELECT_PROFILE" : "Please select the profile on the display",
 
             // appinstalld
             "failed to extract ipk file" : "Please check whether the ipk file is packaged by CLI or not",
@@ -24,7 +24,7 @@ const log = require('npmlog');
             "Cannnot install privileged app on developer mode" : "Please change the app id (app id should not start with 'com.lge', 'com.webos', 'com.palm')",
             "Cannnot remove privileged app on developer mode" : "You cannot remove the privileged app whose app id start with 'com.lge', 'com.webos', 'com.palm'",
             "unable to execute smack" : "Please remove the app and install again",
-            "empty session list, cannot query getAppInfo" : "Please select \"Profile icon\" on display",
+            "empty session list, cannot query getAppInfo" : "Please select the profile on the display",
             "FAILED_REMOVE" :"Please check app is installed to device by ares-install -l",
 
             // applicationmanager

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -12,6 +12,9 @@ const log = require('npmlog');
             // service's error message, common
             "for category \"/dev\"" : "Please enable \"Developer options\" on your device",
 
+            // sessionmanager
+            "ENABLE_PROFILE" : "Please select \"Profile icon\" on display",
+
             // appinstalld
             "failed to extract ipk file" : "Please check whether the ipk file is packaged by CLI or not",
             "Failed to parse control" : "Please check whether the ipk file is packaged by CLI or not",
@@ -21,6 +24,7 @@ const log = require('npmlog');
             "Cannnot install privileged app on developer mode" : "Please change the app id (app id should not start with 'com.lge', 'com.webos', 'com.palm')",
             "Cannnot remove privileged app on developer mode" : "You cannot remove the privileged app whose app id start with 'com.lge', 'com.webos', 'com.palm'",
             "unable to execute smack" : "Please remove the app and install again",
+            "empty session list, cannot query getAppInfo" : "Please select \"Profile icon\" on display",
             "FAILED_REMOVE" :"Please check app is installed to device by ares-install -l",
 
             // applicationmanager

--- a/lib/device.js
+++ b/lib/device.js
@@ -195,7 +195,7 @@ const util = require('util'),
                 if (results[1] !== undefined) {
                     if (typeof results[1] === "object") {
                         if(results[1].length === 0) {
-                            return next(errHndl.getErrMsg("ENABLE_PROFILE"));
+                            return next(errHndl.getErrMsg("SELECT_PROFILE"));
                         }
                         for (let i = 0; i < results[1].length; i++) {
                             resultTxt += convertJsonToList(results[1][i], 0) + '\n';

--- a/lib/device.js
+++ b/lib/device.js
@@ -194,6 +194,9 @@ const util = require('util'),
 
                 if (results[1] !== undefined) {
                     if (typeof results[1] === "object") {
+                        if(results[1].length === 0) {
+                            return next(errHndl.getErrMsg("ENABLE_PROFILE"));
+                        }
                         for (let i = 0; i < results[1].length; i++) {
                             resultTxt += convertJsonToList(results[1][i], 0) + '\n';
                         }

--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -105,6 +105,10 @@ let platformNodeVersion = "0";
                 }
 
                 launcher.listRunningApp(options, function(err, runningApps) {
+                    if (err) {
+                        return next(err);
+                    }
+
                     runningApps = [].concat(runningApps);
                     const runAppIds = runningApps.map(function(app) {
                         return app.id;

--- a/lib/session.js
+++ b/lib/session.js
@@ -36,7 +36,7 @@ const npmlog = require('npmlog'),
 
                     // if sessionList is empty
                     if(resultValue.sessionList.length === 0 ){
-                        return next(errHndl.getErrMsg("ENABLE_PROFILE"));
+                        return next(errHndl.getErrMsg("SELECT_PROFILE"));
                     }
 
                     for (let i = 0; i < resultValue.sessionList.length; i++) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -34,6 +34,11 @@ const npmlog = require('npmlog'),
                         options.display = 0;
                     }
 
+                    // if sessionList is empty
+                    if(resultValue.sessionList.length === 0 ){
+                        return next(errHndl.getErrMsg("ENABLE_PROFILE"));
+                    }
+
                     for (let i = 0; i < resultValue.sessionList.length; i++) {
                         if (resultValue.sessionList[i].deviceSetInfo.displayId === undefined) {
                             return next(errHndl.getErrMsg("NOT_EXIST_DISPLAY"));


### PR DESCRIPTION
:Release Notes:
Add empty session tips for Auto

:Detailed Notes:
After flashing booting, user should select "profile icon" on the screen.
At this time, the session list is empty. So, CLI commands print
unexpected results. Add tips message to user

:Testing Performed:
1. Before run TC, you must select a profile on each display.
    TC passed on AUTO & OSE target and Auto emulator.
2. eslint passed
3. Verified with CLI commands
   a. boot Auto board. The login UI is shown
   b. Run CLI commands. "select profile" tips should be printed.
```
$ ./ares-install.js com.domain.app_1.0.0_all.ipk 
$ ./ares-launch.js -r
$ ./ares-launch.js -H sampleWeb
$ ./ares-launch.js -c com.test.app
$ ./ares-device.js -s
$ ./ares-inspect.js -s com.domian.app.test
$ ./ares-install.js -l
$ ./ares-install.js -F
$ ./ares-shell.js -dp 1
$ ./ares-log.js -ul -dp 1 (on Auto target)
> ares-xxxx ERR! [Tips]: Please select the profile on the display
```

:Issues Addressed:
[PLAT-143757] Add "login profile" tips after flash booting
