### PR TITLE
Change getErrMsg to getErrMsgMap()

### DIFF
--- a/bin/ares-setup-device.js
+++ b/bin/ares-setup-device.js
@@ -235,13 +235,13 @@ function _queryAddRemove(ssdpDevices, next) {
                 },
                 validate: function(input) {
                     if (input.length < 1) {
-                        return errHndl.getErrMsgFromMap("EMPTY_VALUE");
+                        return errHndl.getErrStr("EMPTY_VALUE");
                     }
                     if (deviceNames.indexOf(input) !== -1) {
-                        return errHndl.getErrMsgFromMap("EXISTING_VALUE");
+                        return errHndl.getErrStr("EXISTING_VALUE");
                     }
                     if (!isValidDeviceName(input)) {
-                        return errHndl.getErrMsgFromMap("INVALID_DEVICENAME");
+                        return errHndl.getErrStr("INVALID_DEVICENAME");
                     }
                     return true;
                 }
@@ -286,7 +286,7 @@ function _queryDeviceInfo(selDevice, next) {
         },
         validate: function(answers) {
             if (!isValidIpv4(answers)) {
-                return errHndl.getErrMsgFromMap("INVALID_VALUE");
+                return errHndl.getErrStr("INVALID_VALUE");
             }
             return true;
         },
@@ -302,7 +302,7 @@ function _queryDeviceInfo(selDevice, next) {
         },
         validate: function(answers) {
             if (!isValidPort(answers)) {
-                return errHndl.getErrMsgFromMap("INVALID_VALUE");
+                return errHndl.getErrStr("INVALID_VALUE");
             }
             return true;
         },

--- a/bin/ares-setup-device.js
+++ b/bin/ares-setup-device.js
@@ -235,13 +235,13 @@ function _queryAddRemove(ssdpDevices, next) {
                 },
                 validate: function(input) {
                     if (input.length < 1) {
-                        return errHndl.changeErrMsg("EMPTY_VALUE", "DEVICE_NAME");
+                        return errHndl.getErrMsgFromMap("EMPTY_VALUE");
                     }
                     if (deviceNames.indexOf(input) !== -1) {
-                        return errHndl.changeErrMsg("EXISTING_VALUE", "DEVICE_NAME", input);
+                        return errHndl.getErrMsgFromMap("EXISTING_VALUE");
                     }
                     if (!isValidDeviceName(input)) {
-                        return errHndl.changeErrMsg("INVALID_DEVICENAME");
+                        return errHndl.getErrMsgFromMap("INVALID_DEVICENAME");
                     }
                     return true;
                 }
@@ -286,7 +286,7 @@ function _queryDeviceInfo(selDevice, next) {
         },
         validate: function(answers) {
             if (!isValidIpv4(answers)) {
-                return "Incorrect ip address!";
+                return errHndl.getErrMsgFromMap("INVALID_VALUE");
             }
             return true;
         },
@@ -302,7 +302,7 @@ function _queryDeviceInfo(selDevice, next) {
         },
         validate: function(answers) {
             if (!isValidPort(answers)) {
-                return "Incorrect port number!";
+                return errHndl.getErrMsgFromMap("INVALID_VALUE");
             }
             return true;
         },

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -166,7 +166,7 @@ const log = require('npmlog');
             heading = "";
 
         } else if (orgErrKey === "FAILED_CALL_LUNA" && heading) {
-            mapErrMsg = errMsgHdlr.getErrMsgFromMap(orgErrKey, option, value);
+            mapErrMsg = errMsgHdlr.getErrStr(orgErrKey, option, value);
             if(!mapErrMsg) {
                 return orgErrKey; // Do not change modify this line.
             }
@@ -182,7 +182,7 @@ const log = require('npmlog');
         }
 
         // Create Tips message
-        mapErrMsg = errMsgHdlr.getErrMsgFromMap(errKey, option, value);
+        mapErrMsg = errMsgHdlr.getErrStr(errKey, option, value);
 
         if (mapErrMsg) {
             const tipsErr = new CLIError(heading, mapErrMsg);
@@ -198,8 +198,8 @@ const log = require('npmlog');
         }
     };
 
-    errMsgHdlr.getErrMsgFromMap = function(errKey, option, value) {
-        log.info("errMsgHdlr#getErrMsgFromMap():", "errKey:", errKey, "option:", option, "value:", value);
+    errMsgHdlr.getErrStr = function(errKey, option, value) {
+        log.info("errMsgHdlr#getErrStr():", "errKey:", errKey, "option:", option, "value:", value);
 
         if (!errKey) {
             return errKey;

--- a/lib/log.js
+++ b/lib/log.js
@@ -29,7 +29,7 @@ const util = require('util'),
         show: function(options, next) {
             log.info("log#show");
             if (typeof next !== 'function') {
-                throw errHndl.changeErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
+                throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
 
             options = options || {};
@@ -96,7 +96,7 @@ const util = require('util'),
         readMode: function(options, next) {
             log.info("log#readMode");
             if (typeof next !== 'function') {
-                throw errHndl.changeErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
+                throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
 
             options = options || {};
@@ -181,7 +181,7 @@ const util = require('util'),
         printUnitList: function(options, next) {
             log.info("log#printUnitList");
             if (typeof next !== 'function') {
-                throw errHndl.changeErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
+                throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
 
             options = options || {};


### PR DESCRIPTION
:Release Notes:
Fix invalid value error bug in ares-setup-device

:Detailed Notes:
- If user gives invalid value in ares-setup-device's query mode, 
CLI shows "length" error, which is not expected message
- In query error case, have to return "string" type of error message.
- Change changeErrMsg to getErrMsg in log library

:Testing Performed:
1. TC passed on OSE/Auto target & Auto emulator.
2. eslint passed
3. Verified with CLI commands
 - Give invalid device name
```
$ ares-setup-device
Enter Device Name: emulator // Exist device name
>> The specified value already exists

Enter Device Name: 123 // Invalid device name
>> Invalid device name. The device name should consist of letters, numbers, and special characters ('-','_','#') and should start with letters or '_'

Enter Device Name:     // Empty device name
>> Please specify a value
```
 - Give ip address/port on adding mode
```
Enter Device IP address: 123123adsf
>> Invalid value

Enter Device Port: qwe
>> Invalid value
```

:Issues Addressed:
[PLAT-138374] Prepare to system test of CLI v2.2.0