### PR TITLE
Fix emulator connection of ares-launch -H option

### DIFF
--- a/lib/launch.js
+++ b/lib/launch.js
@@ -67,14 +67,14 @@ const util = require('util'),
 
             function _checkInstalledApp(next){
                 if (options.installMode === "Hosted") {
-                    installer.list(options, function(result) {
+                    installer.list(options, function(err, result) {
                         for (const index in result) {
                             if (result[index].id === hostedAppId) {
                                 hostedAppInstalled = true;
                                 break;
                             }
                         }
-                        next();
+                        next(err);
                     });
                 } else {
                     next();
@@ -83,14 +83,14 @@ const util = require('util'),
 
             function _checkRunningApp(next){
                 if (options.installMode === "Hosted") {
-                    self.listRunningApp(options, function(result) {
+                    self.listRunningApp(options, function(err, result) {
                         for (const index in result) {
                             if (result[index].id === hostedAppId) {
                                 self.close(options,hostedAppId, params, next);
                                 return;
                             }
                         }
-                        next();
+                        next(err);
                     });
                 } else {
                     next();


### PR DESCRIPTION
:Release Notes:
Fix connection error in ares-launch -H option

:Detailed Notes:
- ares-launch -H shows "lunaAddr" error message with emulator turned off
- Fix to it show "connection" error message instead of "lunaAddr"

:Testing Performed:
1. TC passed on OSE target & emulator.
2. ESLint passed
3. Verified with CLI commands with emulator turned off
   $ ./ares-launch.js -H sampleWeb -d emulator
   ares-launch ERR! [syscall failure]: connect ECONNREFUSED 127.0.0.1:6622
   ares-launch ERR! [Tips]: Connection refused. Please check the device IP address or the port number

:Issues Addressed:
[PLAT-138374] Prepare to system test of CLI v2.2.0