### PR TITLE
Update version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.2.0 (June 21, 2021)
+### ares-log
+* Added as a new command for showing or saving logs of webOS apps and services.
+
+### ares-setup-device
+* Updated the naming rule for the DEVICE_NAME parameter.
+
+### ares-install
+* Enhanced the readability of the results of the --listfull option.
+
+### Common
+* Categorized error messages and added user tips according to each error message.
+
+### Meta files
+* Updated the README file.
+
+
 ## 2.1.0 (April 2, 2021)
 ### ares-device
 * Supports screen capture using the `--capture-screen` option.
@@ -9,6 +26,7 @@
 ### ares-shell
 * Fixed an issue that environment variables using the `ares-shell -r` command were different from environment variables of the target device.
 
+
 ## 2.0.3 (January 22, 2021)
 ### ares
 * Updated help message.
@@ -16,8 +34,10 @@
 ### Meta files
 * Updated the README file.
 
+
 ## 2.0.2 (December 29, 2020)
 * Supports Node v14.15.1.
+
 
 ## 2.0.0 (December 11, 2020)
 * Initial github release.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Command Line Interface for development webOS application and service",
   "main": "./bin/ares.js",
   "author": "ye.kim",


### PR DESCRIPTION
:Release Notes:
Update version to 2.2.0

:Detailed Notes:
- Update version in package.json and npm-shrinkwrap.json
- Update CHANGELOG.md

:Testing Performed:
1. Install CLI 2.2.0 package using below command
  $sudo npm uninstall -g @webosose/ares-cli
  $sudo npm install -g https://github.com:webosose/ares-cli.git#Update_version_2.2.0
2. Check version using below command
  $ares -V
  > Version: 2.2.0

:Issues Addressed:
[PLAT-141834] Prepare CLI v2.2.0 release for OSE 2.11.0