### PR TITLE
Fixed browser invocation

### DIFF
--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -71,7 +71,7 @@ let platformNodeVersion = "0";
 
             function _findSdkEnv(next) {
                 const env = new sdkenv.Env();
-                env.getEnvValue("BROWSER", function(browserPath) {
+                env.getEnvValue("BROWSER", function(err, browserPath) {
                     options.bundledBrowserPath = browserPath;
                     next();
                 });


### PR DESCRIPTION
If `LG_WEBOS_CUSTOM_SDK_HOME` has set,  `ares-inspect.cmd --app com.company.package --open` will not open browser properly. This PR fixed this issue.