### PR TITLE
Handle directory permission error

### DIFF
--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -46,6 +46,7 @@ const log = require('npmlog'),
             "ECONNREFUSED": "Connection refused. Please check the device IP address or the port number",
             "ECONNRESET": "Unable to connect to the device. Please check the device",
             "ENOENT": "Please check if the path is valid",
+            "EROFS" : "Please check if the path is writable",
             "TIME_OUT": "Connection timed out. Please check the device IP address or the port number",
             "NO_FREE_SPACE": "Installation failure. Please check if there is sufficient free space in the disk",
 

--- a/lib/base/novacom.js
+++ b/lib/base/novacom.js
@@ -736,8 +736,8 @@ const async = require('async'),
                     if (4 === err.code || 127 === err.code) {
                         log.verbose('Session#get()', "sftp is not available, attempt transfering file via streamPut");
                         const os = fs.createWriteStream(outPath);
-                        os.on('error', function(e) {
-                            setImmediate(next, errHndl.getErrMsg(e));
+                        os.on('error', function(error) {
+                            setImmediate(next, errHndl.getErrMsg(error));
                         });
                         self.streamGet(inPath, os, next);
                     } else {

--- a/lib/base/novacom.js
+++ b/lib/base/novacom.js
@@ -736,6 +736,9 @@ const async = require('async'),
                     if (4 === err.code || 127 === err.code) {
                         log.verbose('Session#get()', "sftp is not available, attempt transfering file via streamPut");
                         const os = fs.createWriteStream(outPath);
+                        os.on('error', function(e) {
+                            setImmediate(next, errHndl.getErrMsg(e));
+                        });
                         self.streamGet(inPath, os, next);
                     } else {
                         setImmediate(next, err);

--- a/lib/device.js
+++ b/lib/device.js
@@ -277,22 +277,30 @@ const async = require('async'),
                     let parseExt = path.parse(options.outputPath).ext;
                     parseExt = parseExt.split('.').pop();
 
-                    log.info("device#capture#_makeCaptureOption():" + " dir name : " + parseDirPath 
+                    log.info("device#capture#_makeCaptureOption():" + " dir name : " + parseDirPath
                         + " ,file name : " + parseBase + " ,inputFormat : " + parseExt);
 
-                    // if given path has extension
-                    if (parseBase && parseExt) {
-                        if (parseExt === "png" || parseExt === "bmp" || parseExt === "jpg") {
-                            captureFormat = parseExt.toUpperCase();
-                        } else {
-                            return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
+                    // If specific path is given
+                    if (parseBase) {
+                        // parseBase is [filename].[ext] format
+                        if (parseExt) {
+                            if (parseExt === "png" || parseExt === "bmp" || parseExt === "jpg") {
+                                captureFormat = parseExt.toUpperCase();
+                            } else {
+                                return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
+                            }
+                            captureFileName = parseBase;
+                            destinationPath = path.resolve(parseDirPath);
+                        } else if (parseExt === "") {
+                            // paresBase is directory path. Use it as destination directory path
+                            captureFileName += createDateFileName(null, captureFormat.toLowerCase());
+                            destinationPath = path.resolve(options.outputPath);
                         }
-                        captureFileName = parseBase;
-                        destinationPath = path.resolve(parseDirPath);
-                    } else if (parseBase && (parseExt === "")) {
-                        // it's directory path. Use it as destination dir Path
+                    } else if (parseDirPath) {
+                        // the path has only "directory" without parseBase
+                        // For example, "ares-device -c /" or "ares-defvice -c ."
                         captureFileName += createDateFileName(null, captureFormat.toLowerCase());
-                        destinationPath = path.resolve(options.outputPath);
+                        destinationPath = path.resolve(parseDirPath);
                     }
                 }
 

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -85,7 +85,7 @@ const async = require('async'),
                                     stats = fs.lstatSync(destinationPath);
                                     if (exists) {
                                         if (stats.isDirectory()) {
-                                            destinationPath = destinationPath + path.sep + path.basename(orginalSourcePath);
+                                            destinationPath = path.resolve(destinationPath, path.basename(orginalSourcePath));
                                         }
                                     }
                                 } catch (err) {

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -67,141 +67,141 @@ describe(aresCmd + ' --device-list(-D)', function() {
     });
 });
 
-// describe(aresCmd, function() {
-//     it('Retrieve device information', function(done) {
-//         const keys = ["webos_build_id","webos_imagename","webos_name","webos_release",
-//                     "webos_manufacturing_version", "core_os_kernel_version", "device_name",
-//                     "device_id", "chromium_version", "qt_version"];
-//         exec(cmd + ` -i ${options.device}`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//             }
-//             keys.forEach(function(key) {
-//                 expect(stdout).toContain(key);
-//             });
-//             done();
-//         });
-//     });
-// });
+describe(aresCmd, function() {
+    it('Retrieve device information', function(done) {
+        const keys = ["webos_build_id","webos_imagename","webos_name","webos_release",
+                    "webos_manufacturing_version", "core_os_kernel_version", "device_name",
+                    "device_id", "chromium_version", "qt_version"];
+        exec(cmd + ` -i ${options.device}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            keys.forEach(function(key) {
+                expect(stdout).toContain(key);
+            });
+            done();
+        });
+    });
+});
 
-// describe(aresCmd, function() {
-//     it('Retrieve session information', function(done) {
-//         const keys = ["sessionId", "displayId"];
-//         exec(cmd + ` -s ${options.device}`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//                 expect(stderr).toContain("ares-device ERR! [com.webos.service.sessionmanager failure]: " +
-//                                         "luna-send command failed <Service does not exist: com.webos.service.sessionmanager.>");
-//                 expect(stderr).toContain("ares-device ERR! [Tips]: This device does not support multiple sessions");
-//             }
-//             else {
-//                 keys.forEach(function(key) {
-//                     expect(stdout).toContain(key);
-//                 });
-//             }
-//             done();
-//         });
-//     });
-// });
+describe(aresCmd, function() {
+    it('Retrieve session information', function(done) {
+        const keys = ["sessionId", "displayId"];
+        exec(cmd + ` -s ${options.device}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+                expect(stderr).toContain("ares-device ERR! [com.webos.service.sessionmanager failure]: " +
+                                        "luna-send command failed <Service does not exist: com.webos.service.sessionmanager.>");
+                expect(stderr).toContain("ares-device ERR! [Tips]: This device does not support multiple sessions");
+            }
+            else {
+                keys.forEach(function(key) {
+                    expect(stdout).toContain(key);
+                });
+            }
+            done();
+        });
+    });
+});
 
-// describe(aresCmd + ' --capture-screen(-c)', function() {
-//     let generatedFile = "";
+describe(aresCmd + ' --capture-screen(-c)', function() {
+    let generatedFile = "";
 
-//     beforeEach(function(done) {
-//         generatedFile = "";
-//         common.removeOutDir(captureDirPath);
-//         done();
-//     });
-//     afterEach(function(done) {
-//         common.removeOutDir(generatedFile);
-//         common.removeOutDir(captureDirPath);
-//         done();
-//     });
+    beforeEach(function(done) {
+        generatedFile = "";
+        common.removeOutDir(captureDirPath);
+        done();
+    });
+    afterEach(function(done) {
+        common.removeOutDir(generatedFile);
+        common.removeOutDir(captureDirPath);
+        done();
+    });
 
-//     it('Capture', function(done) {
-//         exec(cmd + ` -c`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//             }
-//             expect(stdout).toContain(options.device);
-//             expect(stdout).toContain(new Date().getFullYear());
-//             expect(stdout).toContain("display0");
-//             expect(stdout).toContain(".png");
-//             expect(stdout).toContain(path.resolve('.'));
+    it('Capture', function(done) {
+        exec(cmd + ` -c`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            expect(stdout).toContain(options.device);
+            expect(stdout).toContain(new Date().getFullYear());
+            expect(stdout).toContain("display0");
+            expect(stdout).toContain(".png");
+            expect(stdout).toContain(path.resolve('.'));
 
-//             const matchedFiles = stdout.match(dateFileReg);
+            const matchedFiles = stdout.match(dateFileReg);
 
-//             generatedFile = path.join(path.resolve('.'), matchedFiles[0]);
-//             console.log("capture file name : " + matchedFiles[0]);
-//             expect(fs.existsSync(generatedFile)).toBe(true);
-//             done();
-//         });
-//     });
+            generatedFile = path.join(path.resolve('.'), matchedFiles[0]);
+            console.log("capture file name : " + matchedFiles[0]);
+            expect(fs.existsSync(generatedFile)).toBe(true);
+            done();
+        });
+    });
 
-//     it('Capture with filename', function(done) {
-//         exec(cmd + ` -c screen.png`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//             }
-//             expect(stdout).toContain("[Info] Set target device : " + options.device);
-//             expect(stdout).not.toContain("display0");
-//             expect(stdout).toContain("screen.png");
-//             expect(stdout).toContain(path.resolve('.'));
+    it('Capture with filename', function(done) {
+        exec(cmd + ` -c screen.png`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            expect(stdout).toContain("[Info] Set target device : " + options.device);
+            expect(stdout).not.toContain("display0");
+            expect(stdout).toContain("screen.png");
+            expect(stdout).toContain(path.resolve('.'));
 
-//             generatedFile = path.join(path.resolve('.'), "screen.png");
-//             expect(fs.existsSync(generatedFile)).toBe(true);
-//             done();
-//         });
-//     });
+            generatedFile = path.join(path.resolve('.'), "screen.png");
+            expect(fs.existsSync(generatedFile)).toBe(true);
+            done();
+        });
+    });
 
-//     it('Capture with directory Path & display option', function(done) {
-//         exec(cmd + ` -c ${captureDirPath} --display 1`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//             }
-//             expect(stdout).toContain(options.device);
-//             expect(stdout).toContain(new Date().getFullYear());
-//             expect(stdout).toContain("display1");
-//             expect(stdout).toContain(".png");
-//             expect(stdout).toContain(captureDirPath);
-//             expect(fs.existsSync(captureDirPath)).toBe(true);
+    it('Capture with directory Path & display option', function(done) {
+        exec(cmd + ` -c ${captureDirPath} --display 1`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            expect(stdout).toContain(options.device);
+            expect(stdout).toContain(new Date().getFullYear());
+            expect(stdout).toContain("display1");
+            expect(stdout).toContain(".png");
+            expect(stdout).toContain(captureDirPath);
+            expect(fs.existsSync(captureDirPath)).toBe(true);
 
-//             const matchedFiles = stdout.match(dateFileReg);
+            const matchedFiles = stdout.match(dateFileReg);
 
-//             console.log("capture file name : " + matchedFiles[0]);
-//             expect(fs.existsSync(path.join(captureDirPath, matchedFiles[0]))).toBe(true);
-//             done();
-//         });
-//     });
+            console.log("capture file name : " + matchedFiles[0]);
+            expect(fs.existsSync(path.join(captureDirPath, matchedFiles[0]))).toBe(true);
+            done();
+        });
+    });
 
-//     it('Capture with directory & file path(bmp)', function(done) {
-//         const captureFilePath = path.join(captureDirPath, "screen.bmp");
-//         exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//             }
-//             expect(stdout).not.toContain("display0");
-//             expect(stdout).toContain("screen.bmp");
-//             expect(stdout).toContain(captureDirPath);
-//             expect(fs.existsSync(captureDirPath)).toBe(true);
-//             done();
-//         });
-//     });
+    it('Capture with directory & file path(bmp)', function(done) {
+        const captureFilePath = path.join(captureDirPath, "screen.bmp");
+        exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            expect(stdout).not.toContain("display0");
+            expect(stdout).toContain("screen.bmp");
+            expect(stdout).toContain(captureDirPath);
+            expect(fs.existsSync(captureDirPath)).toBe(true);
+            done();
+        });
+    });
 
-//     it('Capture with directory & file path(jpg)', function(done) {
-//         const captureFilePath = path.join(captureDirPath, "screen.jpg");
-//         exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
-//             if (stderr && stderr.length > 0) {
-//                 common.detectNodeMessage(stderr);
-//             }
-//             expect(stdout).not.toContain("display0");
-//             expect(stdout).toContain("screen.jpg");
-//             expect(stdout).toContain(captureDirPath);
-//             expect(fs.existsSync(captureDirPath)).toBe(true);
-//             done();
-//         });
-//     });
-// });
+    it('Capture with directory & file path(jpg)', function(done) {
+        const captureFilePath = path.join(captureDirPath, "screen.jpg");
+        exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            expect(stdout).not.toContain("display0");
+            expect(stdout).toContain("screen.jpg");
+            expect(stdout).toContain(captureDirPath);
+            expect(fs.existsSync(captureDirPath)).toBe(true);
+            done();
+        });
+    });
+});
 
 describe(aresCmd + ' negative TC', function() {
     const noPermDirPath = path.join(__dirname, "..", "tempFiles", "noPermDir");
@@ -230,7 +230,6 @@ describe(aresCmd + ' negative TC', function() {
         exec(cmd + ` -c ${noPermDirPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-                console.log(stderr);
                 expect(stderr).toContain("ares-device ERR! [syscall failure]: EACCES: permission denied, open");
                 expect(stderr).toContain("ares-device ERR! [Tips]: No permission to execute. Please check the directory permission");
             }

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -230,7 +230,7 @@ describe(aresCmd + ' negative TC', function() {
         exec(cmd + ` -c ${noPermDirPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-                expect(stderr).toContain("ares-device ERR! [syscall failure]: EACCES: permission denied, open");
+                expect(stderr).toContain("ares-device ERR! [syscall failure]: EACCES: permission denied");
                 expect(stderr).toContain("ares-device ERR! [Tips]: No permission to execute. Please check the directory permission");
             }
             done();

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -67,143 +67,155 @@ describe(aresCmd + ' --device-list(-D)', function() {
     });
 });
 
-describe(aresCmd, function() {
-    it('Retrieve device information', function(done) {
-        const keys = ["webos_build_id","webos_imagename","webos_name","webos_release",
-                    "webos_manufacturing_version", "core_os_kernel_version", "device_name",
-                    "device_id", "chromium_version", "qt_version"];
-        exec(cmd + ` -i ${options.device}`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            keys.forEach(function(key) {
-                expect(stdout).toContain(key);
-            });
-            done();
-        });
-    });
-});
+// describe(aresCmd, function() {
+//     it('Retrieve device information', function(done) {
+//         const keys = ["webos_build_id","webos_imagename","webos_name","webos_release",
+//                     "webos_manufacturing_version", "core_os_kernel_version", "device_name",
+//                     "device_id", "chromium_version", "qt_version"];
+//         exec(cmd + ` -i ${options.device}`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//             }
+//             keys.forEach(function(key) {
+//                 expect(stdout).toContain(key);
+//             });
+//             done();
+//         });
+//     });
+// });
 
-describe(aresCmd, function() {
-    it('Retrieve session information', function(done) {
-        const keys = ["sessionId", "displayId"];
-        exec(cmd + ` -s ${options.device}`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-                expect(stderr).toContain("ares-device ERR! [com.webos.service.sessionmanager failure]: " +
-                                        "luna-send command failed <Service does not exist: com.webos.service.sessionmanager.>");
-                expect(stderr).toContain("ares-device ERR! [Tips]: This device does not support multiple sessions");
-            }
-            else {
-                keys.forEach(function(key) {
-                    expect(stdout).toContain(key);
-                });
-            }
-            done();
-        });
-    });
-});
+// describe(aresCmd, function() {
+//     it('Retrieve session information', function(done) {
+//         const keys = ["sessionId", "displayId"];
+//         exec(cmd + ` -s ${options.device}`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//                 expect(stderr).toContain("ares-device ERR! [com.webos.service.sessionmanager failure]: " +
+//                                         "luna-send command failed <Service does not exist: com.webos.service.sessionmanager.>");
+//                 expect(stderr).toContain("ares-device ERR! [Tips]: This device does not support multiple sessions");
+//             }
+//             else {
+//                 keys.forEach(function(key) {
+//                     expect(stdout).toContain(key);
+//                 });
+//             }
+//             done();
+//         });
+//     });
+// });
 
-describe(aresCmd + ' --capture-screen(-c)', function() {
-    let generatedFile = "";
+// describe(aresCmd + ' --capture-screen(-c)', function() {
+//     let generatedFile = "";
 
-    beforeEach(function(done) {
-        generatedFile = "";
-        common.removeOutDir(captureDirPath);
-        done();
-    });
-    afterEach(function(done) {
-        common.removeOutDir(generatedFile);
-        common.removeOutDir(captureDirPath);
-        done();
-    });
+//     beforeEach(function(done) {
+//         generatedFile = "";
+//         common.removeOutDir(captureDirPath);
+//         done();
+//     });
+//     afterEach(function(done) {
+//         common.removeOutDir(generatedFile);
+//         common.removeOutDir(captureDirPath);
+//         done();
+//     });
 
-    it('Capture', function(done) {
-        exec(cmd + ` -c`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            expect(stdout).toContain(options.device);
-            expect(stdout).toContain(new Date().getFullYear());
-            expect(stdout).toContain("display0");
-            expect(stdout).toContain(".png");
-            expect(stdout).toContain(path.resolve('.'));
+//     it('Capture', function(done) {
+//         exec(cmd + ` -c`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//             }
+//             expect(stdout).toContain(options.device);
+//             expect(stdout).toContain(new Date().getFullYear());
+//             expect(stdout).toContain("display0");
+//             expect(stdout).toContain(".png");
+//             expect(stdout).toContain(path.resolve('.'));
 
-            const matchedFiles = stdout.match(dateFileReg);
+//             const matchedFiles = stdout.match(dateFileReg);
 
-            generatedFile = path.join(path.resolve('.'), matchedFiles[0]);
-            console.log("capture file name : " + matchedFiles[0]);
-            expect(fs.existsSync(generatedFile)).toBe(true);
-            done();
-        });
-    });
+//             generatedFile = path.join(path.resolve('.'), matchedFiles[0]);
+//             console.log("capture file name : " + matchedFiles[0]);
+//             expect(fs.existsSync(generatedFile)).toBe(true);
+//             done();
+//         });
+//     });
 
-    it('Capture with filename', function(done) {
-        exec(cmd + ` -c screen.png`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            expect(stdout).toContain("[Info] Set target device : " + options.device);
-            expect(stdout).not.toContain("display0");
-            expect(stdout).toContain("screen.png");
-            expect(stdout).toContain(path.resolve('.'));
+//     it('Capture with filename', function(done) {
+//         exec(cmd + ` -c screen.png`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//             }
+//             expect(stdout).toContain("[Info] Set target device : " + options.device);
+//             expect(stdout).not.toContain("display0");
+//             expect(stdout).toContain("screen.png");
+//             expect(stdout).toContain(path.resolve('.'));
 
-            generatedFile = path.join(path.resolve('.'), "screen.png");
-            expect(fs.existsSync(generatedFile)).toBe(true);
-            done();
-        });
-    });
+//             generatedFile = path.join(path.resolve('.'), "screen.png");
+//             expect(fs.existsSync(generatedFile)).toBe(true);
+//             done();
+//         });
+//     });
 
-    it('Capture with directory Path & display option', function(done) {
-        exec(cmd + ` -c ${captureDirPath} --display 1`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            expect(stdout).toContain(options.device);
-            expect(stdout).toContain(new Date().getFullYear());
-            expect(stdout).toContain("display1");
-            expect(stdout).toContain(".png");
-            expect(stdout).toContain(captureDirPath);
-            expect(fs.existsSync(captureDirPath)).toBe(true);
+//     it('Capture with directory Path & display option', function(done) {
+//         exec(cmd + ` -c ${captureDirPath} --display 1`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//             }
+//             expect(stdout).toContain(options.device);
+//             expect(stdout).toContain(new Date().getFullYear());
+//             expect(stdout).toContain("display1");
+//             expect(stdout).toContain(".png");
+//             expect(stdout).toContain(captureDirPath);
+//             expect(fs.existsSync(captureDirPath)).toBe(true);
 
-            const matchedFiles = stdout.match(dateFileReg);
+//             const matchedFiles = stdout.match(dateFileReg);
 
-            console.log("capture file name : " + matchedFiles[0]);
-            expect(fs.existsSync(path.join(captureDirPath, matchedFiles[0]))).toBe(true);
-            done();
-        });
-    });
+//             console.log("capture file name : " + matchedFiles[0]);
+//             expect(fs.existsSync(path.join(captureDirPath, matchedFiles[0]))).toBe(true);
+//             done();
+//         });
+//     });
 
-    it('Capture with directory & file path(bmp)', function(done) {
-        const captureFilePath = path.join(captureDirPath, "screen.bmp");
-        exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            expect(stdout).not.toContain("display0");
-            expect(stdout).toContain("screen.bmp");
-            expect(stdout).toContain(captureDirPath);
-            expect(fs.existsSync(captureDirPath)).toBe(true);
-            done();
-        });
-    });
+//     it('Capture with directory & file path(bmp)', function(done) {
+//         const captureFilePath = path.join(captureDirPath, "screen.bmp");
+//         exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//             }
+//             expect(stdout).not.toContain("display0");
+//             expect(stdout).toContain("screen.bmp");
+//             expect(stdout).toContain(captureDirPath);
+//             expect(fs.existsSync(captureDirPath)).toBe(true);
+//             done();
+//         });
+//     });
 
-    it('Capture with directory & file path(jpg)', function(done) {
-        const captureFilePath = path.join(captureDirPath, "screen.jpg");
-        exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            expect(stdout).not.toContain("display0");
-            expect(stdout).toContain("screen.jpg");
-            expect(stdout).toContain(captureDirPath);
-            expect(fs.existsSync(captureDirPath)).toBe(true);
-            done();
-        });
-    });
-});
+//     it('Capture with directory & file path(jpg)', function(done) {
+//         const captureFilePath = path.join(captureDirPath, "screen.jpg");
+//         exec(cmd + ` -c ${captureFilePath}`, function (error, stdout, stderr) {
+//             if (stderr && stderr.length > 0) {
+//                 common.detectNodeMessage(stderr);
+//             }
+//             expect(stdout).not.toContain("display0");
+//             expect(stdout).toContain("screen.jpg");
+//             expect(stdout).toContain(captureDirPath);
+//             expect(fs.existsSync(captureDirPath)).toBe(true);
+//             done();
+//         });
+//     });
+// });
 
 describe(aresCmd + ' negative TC', function() {
+    const noPermDirPath = path.join(__dirname, "..", "tempFiles", "noPermDir");
+
+    beforeAll(function(done) { 
+        common.createOutDir(noPermDirPath, '0577');
+        done();
+    });
+
+    afterAll(function(done) {
+        common.removeOutDir(noPermDirPath);
+        done();
+    });
+    
     it('Capture with invalid file format', function(done) {
         exec(cmd + ` -c "test.abc"`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
@@ -215,11 +227,12 @@ describe(aresCmd + ' negative TC', function() {
     });
 
     it('Capture with invalid destiation Path', function(done) {
-        exec(cmd + ` -c /rootDir`, function (error, stdout, stderr) {
+        exec(cmd + ` -c ${noPermDirPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-                expect(stderr).toContain("ares-device ERR! [syscall failure]: EACCES: permission denied, mkdir '/rootDir'");
-                expect(stderr).toContain("ares-device ERR! [Tips]: No permission to execute. Please check the directory permission </rootDir>");
+                console.log(stderr);
+                expect(stderr).toContain("ares-device ERR! [syscall failure]: EACCES: permission denied, open");
+                expect(stderr).toContain("ares-device ERR! [Tips]: No permission to execute. Please check the directory permission");
             }
             done();
         });

--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -41,19 +41,22 @@ commonSpec.getOptions = function() {
     return new Promise(function(resolve, reject){
         const argv = nopt(knownOpts, shortHands, process.argv, 2);
 
-        if(argv.device)
+        if (argv.device) {
             options.device = argv.device;
-        if(argv.ip)
+        }
+        if (argv.ip) {
             options.ip = argv.ip;
-        if(options.device !== "emulator")
+        }
+        if (options.device !== "emulator") {
             options.port = argv.port ? argv.port : 22;
+        }
 
         console.info(`device : ${options.device}, ip : ${options.ip}, port : ${options.port}`);
 
         // set profile
         const cmd = commonSpec.makeCmd('ares-config');
         exec(cmd, function (error, stdout) {
-            if(error){
+            if (error) {
                 console.error("set config error " +  error);
                 reject(stdout);
             }
@@ -79,7 +82,7 @@ commonSpec.resetDeviceList = function() {
     return new Promise(function(resolve, reject) {
         const cmd = commonSpec.makeCmd('ares-setup-device');
         exec(cmd + ' -R', function (error, stdout, stderr) {
-            if(!stderr){
+            if (!stderr) {
                 resolve(true);
             } else {
                 reject(error);
@@ -93,7 +96,7 @@ commonSpec.addDeviceInfo = function() {
         const cmd = commonSpec.makeCmd('ares-setup-device');
         exec(cmd + ` -a ${options.device} -i port=${options.port} -i username=root -i host=${options.ip} -i default=true`,
         function (error, stdout, stderr) {
-            if(stderr) {
+            if (stderr) {
                 reject(stderr);
             } else {
                 resolve(stdout);
@@ -109,11 +112,11 @@ commonSpec.makeCmd = function(cmd) {
 commonSpec.createOutDir = function(filePath, mode) {
     if (!fs.existsSync(filePath)) {
         shelljs.mkdir(filePath);
-    }
-    if (mode) {
-        fs.chmodSync(filePath, mode);
-    }
 
+        if (mode) {
+            fs.chmodSync(filePath, mode);
+        }
+    }
 };
 
 commonSpec.removeOutDir = function(filePath) {

--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -112,10 +112,10 @@ commonSpec.makeCmd = function(cmd) {
 commonSpec.createOutDir = function(filePath, mode) {
     if (!fs.existsSync(filePath)) {
         shelljs.mkdir(filePath);
+    }
 
-        if (mode) {
-            fs.chmodSync(filePath, mode);
-        }
+    if (mode) {
+        fs.chmodSync(filePath, mode);
     }
 };
 

--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -106,9 +106,20 @@ commonSpec.makeCmd = function(cmd) {
     return `node ${path.join('bin', cmd + '.js')}`;
 };
 
+commonSpec.createOutDir = function(filePath, mode) {
+    if (!fs.existsSync(filePath)) {
+        shelljs.mkdir(filePath);
+    }
+    if (mode) {
+        fs.chmodSync(filePath, mode);
+    }
+
+};
+
 commonSpec.removeOutDir = function(filePath) {
-    if(fs.existsSync(filePath))
+    if (fs.existsSync(filePath)) {
         shelljs.rm('-rf', filePath);
+    }
 };
 
 commonSpec.detectNodeMessage = function(stderr) {


### PR DESCRIPTION
:Release Notes:
Handle directory permission error

:Detailed Notes:
- Mac(M1) shows "EROFS" error when ares-device negative case executed
  with read-only files system path so that CLI Unit test failed.
- Change the TC to get the same error text on Windows, Linux and Mac
- Add "EROFS" CLI tips message
- Fix "ares-device -c /" error message 

:Testing Performed:
1. Passed CLI Unit test
2. Passed ESlint
3. Give ares-device -c with the read-only file system path on Mac(M1)
```
$ ./ares-device.js -c /
$ ./ares-device.js -c /rootDir
[Info] Set target device : rpi4
ares-device ERR! [syscall failure]: EROFS: read-only file system, [open/make] 'FILEPATH'
ares-device ERR! [Tips]: Please check if the path is writable <FILEPATH>
```
4. Give ares-device -c with the "root(/)" path on Linux
```
$ ./ares-device.js -c /
$ ./ares-device.js -c /rootDir
[Info] Set target device : rpi4
ares-device ERR! [syscall failure]: EACCES: permission denied, [open/make] 'FILEPATH'
ares-device ERR! [Tips]: No permission to execute. Please check the directory permission <FILEPATH>
```

:Issues Addressed:
[WRN-2744] Handle directory permission error