### PR TITLE
Add time interval setting in unit test

### DIFF
--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -52,11 +52,11 @@ commonSpec.getOptions = function() {
         if (options.device !== "emulator") {
             options.port = argv.port ? argv.port : 22;
         }
-        if (argv.timeInterval){
+        if (argv.timeInterval) {
             jasmine.DEFAULT_TIMEOUT_INTERVAL = argv.timeInterval;
         }
 
-        console.info(`device : ${options.device}, ip : ${options.ip}, port : ${options.port}, TimeInterval : ${jasmine.DEFAULT_TIMEOUT_INTERVAL}`);
+        console.info(`device : ${options.device}, ip : ${options.ip}, port : ${options.port}, timeInterval : ${jasmine.DEFAULT_TIMEOUT_INTERVAL}`);
 
         // set profile
         const cmd = commonSpec.makeCmd('ares-config');

--- a/spec/jsSpecs/common-spec.js
+++ b/spec/jsSpecs/common-spec.js
@@ -29,12 +29,14 @@ if (typeof module !== 'undefined' && module.exports) {
 const knownOpts = {
     "device":  String,
     "ip":  String,
-    "port": String
+    "port": String,
+    "timeInterval": Number
 };
 const shortHands = {
     "d": ["--device"],
     "ip": ["--ip"],
-    "port": ["--port"]
+    "port": ["--port"],
+    "ti": ["--timeInterval"]
 };
 
 commonSpec.getOptions = function() {
@@ -50,8 +52,11 @@ commonSpec.getOptions = function() {
         if (options.device !== "emulator") {
             options.port = argv.port ? argv.port : 22;
         }
+        if (argv.timeInterval){
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = argv.timeInterval;
+        }
 
-        console.info(`device : ${options.device}, ip : ${options.ip}, port : ${options.port}`);
+        console.info(`device : ${options.device}, ip : ${options.ip}, port : ${options.port}, TimeInterval : ${jasmine.DEFAULT_TIMEOUT_INTERVAL}`);
 
         // set profile
         const cmd = commonSpec.makeCmd('ares-config');


### PR DESCRIPTION
:Release Notes:
Add time interval setting in unit test

:Detailed Notes:
- Sometimes unit test failure due to time out occurs.
  when executing unit test depending on host pc performance.
- Added time interval setting when run the unit test to solve the problem.

:Testing Performed:
1. Pass unit test on ose
2. Pass eslint
3. Check time interval setting and test result
3-1. Change default time interval to fail the unit test
3-2. Check to no unit test failure when executing unit test command as like,
    $ jasmine --device=ose --ip=123.456.789.10 --timeInterval=12000

:Issues Addressed:
[WRN-2921] Add function to modify default timeout interval