### PR TITLE
Support csv file

### DIFF
--- a/bin/ares-device.js
+++ b/bin/ares-device.js
@@ -52,7 +52,7 @@ const knownOpts = {
 
 const shortHands = {
     "i": ["--system-info"],
-    "sn": ["--session-info"],
+    "se": ["--session-info"],
     "r": ["--resource-monitor"],
     "l": ["--list"],
     "id":["--id-filter"],
@@ -155,11 +155,9 @@ function getResourceMonitor() {
     if (argv.argv.cooked.indexOf("--time-interval") !== -1 ) {
         if (!argv["time-interval"]) {
             // when user does not give the time-interval
-            // for example : ares-device -r -t -d target
             return finish(errHndl.getErrMsg("EMPTY_VALUE", "time-interval"));
         } else if (argv.argv.original.indexOf(options.interval.toString()) === -1) {
             // nopt set default value "1" when user puts only "-t" option without value
-            // for example : ares-device -r t
             return finish(errHndl.getErrMsg("EMPTY_VALUE", "time-interval"));
         }
         if (options.interval <= 0) {
@@ -177,10 +175,8 @@ function getResourceMonitor() {
         options.id = argv["id-filter"];
         deviceLib.processResource(options, finish);
     } else if (argv.list) {
-        // print all running app and service's resource usage
         deviceLib.processResource(options, finish);
     } else {
-        // print all CPUs and memories usage
         deviceLib.systemResource(options, finish);
     }
 }

--- a/bin/ares-device.js
+++ b/bin/ares-device.js
@@ -52,14 +52,14 @@ const knownOpts = {
 
 const shortHands = {
     "i": ["--system-info"],
-    "s": ["--session-info"],
+    "sn": ["--session-info"],
     "r": ["--resource-monitor"],
     "l": ["--list"],
     "id":["--id-filter"],
     "t": ["--time-interval"],
-    "S": ["--save"],
+    "s": ["--save"],
     "c": ["--capture-screen"],
-    "dp" : ["--display"],
+    "dp": ["--display"],
     "d": ["--device"],
     "D": ["--device-list"],
     "V": ["--version"],

--- a/bin/ares-device.js
+++ b/bin/ares-device.js
@@ -38,8 +38,9 @@ const knownOpts = {
     "resource-monitor": Boolean,
     // resource-monitor parameter
     "list" : Boolean,
+    "id-filter" : [String, null],
     "time-interval" : Number,
-    "save" : [String, null],
+    "save" : Boolean,
     "capture-screen" : Boolean,
     "display" : Number,
     "device":   [String, null],
@@ -54,8 +55,9 @@ const shortHands = {
     "s": ["--session-info"],
     "r": ["--resource-monitor"],
     "l": ["--list"],
+    "id":["--id-filter"],
     "t": ["--time-interval"],
-    "S" : ["--save"],
+    "S": ["--save"],
     "c": ["--capture-screen"],
     "dp" : ["--display"],
     "d": ["--device"],
@@ -147,8 +149,9 @@ function getSessionInfo() {
 
 function getResourceMonitor() {
     options.interval = argv["time-interval"] || null;
-    options.outPath = argv["save"] || null;
-    
+    options.save = argv["save"] || null;
+    options.outputPath = argv.argv.remain[0] || null;
+
     if (argv.argv.cooked.indexOf("--time-interval") !== -1 ) {
         if (!argv["time-interval"]) {
             // when user does not give the time-interval
@@ -165,12 +168,16 @@ function getResourceMonitor() {
     }
     log.info("getResourceMonitor()", "interval:", options.interval);
 
-    if (argv.list) {
-        // print all running app and service's resource usage
+    if (argv["id-filter"]) {
+        // Handle when another option appears without id-filter value
+        const idReg = /^-/;
+        if (argv["id-filter"] === "true" || argv["id-filter"].match(idReg)) {
+            return finish(errHndl.getErrMsg("EMPTY_VALUE", "id-filter"));
+        }
+        options.id = argv["id-filter"];
         deviceLib.processResource(options, finish);
-    } else if (argv.argv.remain.length !== 0) {
-        // print specified AppID or ServiceID in argv
-        options.id = argv.argv.remain[0];
+    } else if (argv.list) {
+        // print all running app and service's resource usage
         deviceLib.processResource(options, finish);
     } else {
         // print all CPUs and memories usage

--- a/bin/ares-device.js
+++ b/bin/ares-device.js
@@ -39,6 +39,7 @@ const knownOpts = {
     // resource-monitor parameter
     "list" : Boolean,
     "time-interval" : Number,
+    "save" : [String, null],
     "capture-screen" : Boolean,
     "display" : Number,
     "device":   [String, null],
@@ -54,6 +55,7 @@ const shortHands = {
     "r": ["--resource-monitor"],
     "l": ["--list"],
     "t": ["--time-interval"],
+    "S" : ["--save"],
     "c": ["--capture-screen"],
     "dp" : ["--display"],
     "d": ["--device"],
@@ -145,6 +147,8 @@ function getSessionInfo() {
 
 function getResourceMonitor() {
     options.interval = argv["time-interval"] || null;
+    options.outPath = argv["save"] || null;
+    
     if (argv.argv.cooked.indexOf("--time-interval") !== -1 ) {
         if (!argv["time-interval"]) {
             // when user does not give the time-interval

--- a/files/help/ares-device.help
+++ b/files/help/ares-device.help
@@ -6,16 +6,17 @@
     "synopsis" : {
         "default" : [
             "ares-device",
-            "ares-device [OPTION...]",
-            "ares-device --resource-monitor <APP_ID || SERVICE_ID>"
+            "ares-device [OPTION...]"
         ]
     },
     "description" : {
         "default": [
             "This command displays the device information and supports screen capture.",
             "",
-            "APP_ID is ID of the specific app for display its resource usage.",
-            "SERVICE_ID ID of the specific service for display its resource usage.",
+            "ID is the specific app or service for display its resource usage.",
+            "",
+            "SAVED_FILE is the output directory or file path to save resource usage.",
+            "The file format can be only \"csv\".",
             "",
             "OUTPUT_PATH is the output directory or file path of capture file.",
             "The file format can be \"png\", \"jpg\" and \"bmp\". \"png\" is default.",
@@ -25,16 +26,24 @@
     },
     "options" : {
         "cmdOpt":"option",
-        "default" : ["system", "session", "resource", "list", "interval", "capture", "display", "device", "device-list", "help", "version", "verbose", "level"],
+        "default" : ["system", "session", "resource", "list", "id-filter", "interval", "save", "capture", "display", "device", "device-list", "help", "version", "verbose", "level"],
         "system" : "-i, --system-info @TAB@ Display the device system information",
         "session" : "-s, --session-info @TAB@ Display the device session information",
-        "resource" : "-r, --resource-monitor @TAB@ Display the device CPUs and memories information",
+        "resource" : "-r, --resource-monitor @TAB@ Display the device resource usage",
         "list" : [
-            "-l, --list @TAB@ Display CPUs and memories usage of running apps and services",
+            "-l, --list @TAB@ Display resource usage of running apps and services",
+            "@TAB@ Use it with resource-monitor option"
+        ],
+        "id-filter" : [
+            "-id, --id-filter <ID> @TAB@ Show resource usage of an app or service",
             "@TAB@ Use it with resource-monitor option"
         ],
         "interval" : [
             "-t, --time-interval @TAB@ Set the time for the output cycle(seconds)",
+            "@TAB@ Use it with resource-monitor option"
+        ],
+        "save" : [
+            "-s, --save <SAVED_FILE> @TAB@ Save resorce usage to SAVED_FILE",
             "@TAB@ Use it with resource-monitor option"
         ],
         "capture" : "-c, --capture-screen <OUTPUT_PATH> @TAB@ Capture screen and save the file to the host machine",
@@ -60,14 +69,17 @@
             "# Display session information",
             "ares-device -s -d DEVICE",
             "",
-            "# Display CPUs and memories usage with time interval",
+            "# Display resource usage with time interval",
             "ares-device -r -t 1 -d DEVICE",
             "",
-            "# Display CPUs and memories usage of running app and service",
+            "# Display resource usage and save them to a csv file",
+            "ares-device -r -S -d DEVICE",
+            "",
+            "# Display resource usage of running app and service",
             "ares-device -r -l -t 3 -d DEVICE",
             "",
-            "# Display CPUs and memories usage of specified running app",
-            "ares-device -r com.examples.app -t 5 -d DEVICE",
+            "# Display resource usage of specified running app",
+            "ares-device -r -id com.examples.app -t 5 -d DEVICE",
             "",
             "# Capture the screen of display 1 as screen.png",
             "ares-device -c screen.png -dp 1 -d DEVICE",

--- a/files/help/ares-device.help
+++ b/files/help/ares-device.help
@@ -26,9 +26,9 @@
     },
     "options" : {
         "cmdOpt":"option",
-        "default" : ["system", "session", "resource", "list", "id-filter", "interval", "save", "capture", "display", "device", "device-list", "help", "version", "verbose", "level"],
+        "default" : ["system", "resource", "list", "id-filter", "interval", "save", "capture", "display", "device", "device-list", "help", "version", "verbose", "level"],
         "system" : "-i, --system-info @TAB@ Display the device system information",
-        "session" : "-s, --session-info @TAB@ Display the device session information",
+        "session" : "-sn, --session-info @TAB@ Display the device session information",
         "resource" : "-r, --resource-monitor @TAB@ Display the device resource usage",
         "list" : [
             "-l, --list @TAB@ Display resource usage of running apps and services",
@@ -43,7 +43,7 @@
             "@TAB@ Use it with resource-monitor option"
         ],
         "save" : [
-            "-S, --save <FILE_PATH> @TAB@ Save resorce usage to FILE_PATH",
+            "-s, --save <FILE_PATH> @TAB@ Save resorce usage to FILE_PATH",
             "@TAB@ Use it with resource-monitor option"
         ],
         "capture" : "-c, --capture-screen <OUTPUT_PATH> @TAB@ Capture screen and save the file to the host machine",
@@ -66,14 +66,11 @@
             "# Display system information",
             "ares-device -i -d DEVICE",
             "",
-            "# Display session information",
-            "ares-device -s -d DEVICE",
-            "",
             "# Display resource usage with time interval",
             "ares-device -r -t 1 -d DEVICE",
             "",
             "# Display resource usage and save them to a csv file",
-            "ares-device -r -S -d DEVICE",
+            "ares-device -r -s -d DEVICE",
             "",
             "# Display resource usage of running app and service",
             "ares-device -r -l -t 3 -d DEVICE",

--- a/files/help/ares-device.help
+++ b/files/help/ares-device.help
@@ -15,7 +15,7 @@
             "",
             "ID is the specific app or service for display its resource usage.",
             "",
-            "SAVED_FILE is the output directory or file path to save resource usage.",
+            "FILE_PATH is the output directory or file path to save resource usage.",
             "The file format can be only \"csv\".",
             "",
             "OUTPUT_PATH is the output directory or file path of capture file.",
@@ -43,7 +43,7 @@
             "@TAB@ Use it with resource-monitor option"
         ],
         "save" : [
-            "-s, --save <SAVED_FILE> @TAB@ Save resorce usage to SAVED_FILE",
+            "-S, --save <FILE_PATH> @TAB@ Save resorce usage to FILE_PATH",
             "@TAB@ Use it with resource-monitor option"
         ],
         "capture" : "-c, --capture-screen <OUTPUT_PATH> @TAB@ Capture screen and save the file to the host machine",

--- a/files/help/ares-device.help
+++ b/files/help/ares-device.help
@@ -13,12 +13,12 @@
         "default": [
             "This command displays the device information and supports screen capture.",
             "",
-            "ID is the specific app or service for display its resource usage.",
+            "ID is the specific app or service for display its system resource usage.",
             "",
-            "FILE_PATH is the output directory or file path to save resource usage.",
+            "CSV_FILE is file name or file path to save system resource usage.",
             "The file format can be only \"csv\".",
             "",
-            "OUTPUT_PATH is the output directory or file path of capture file.",
+            "CAPTURE_FILE is file name or file path of capture file.",
             "The file format can be \"png\", \"jpg\" and \"bmp\". \"png\" is default.",
             "",
             "LEVEL is priority of logs. (e.g., silly, verbose, info, warn, error)"
@@ -28,14 +28,14 @@
         "cmdOpt":"option",
         "default" : ["system", "resource", "list", "id-filter", "interval", "save", "capture", "display", "device", "device-list", "help", "version", "verbose", "level"],
         "system" : "-i, --system-info @TAB@ Display the device system information",
-        "session" : "-sn, --session-info @TAB@ Display the device session information",
-        "resource" : "-r, --resource-monitor @TAB@ Display the device resource usage",
+        "session" : "-se, --session-info @TAB@ Display the device session information",
+        "resource" : "-r, --resource-monitor @TAB@ Display the device's system resource usage",
         "list" : [
-            "-l, --list @TAB@ Display resource usage of running apps and services",
+            "-l, --list @TAB@ Display system resource usage of running apps and services",
             "@TAB@ Use it with resource-monitor option"
         ],
         "id-filter" : [
-            "-id, --id-filter <ID> @TAB@ Show resource usage of an app or service",
+            "-id, --id-filter <ID> @TAB@ Show system resource usage of an app or service",
             "@TAB@ Use it with resource-monitor option"
         ],
         "interval" : [
@@ -43,10 +43,10 @@
             "@TAB@ Use it with resource-monitor option"
         ],
         "save" : [
-            "-s, --save <FILE_PATH> @TAB@ Save resorce usage to FILE_PATH",
+            "-s, --save <CSV_FILE> @TAB@ Save resorce usage to CSV_FILE",
             "@TAB@ Use it with resource-monitor option"
         ],
-        "capture" : "-c, --capture-screen <OUTPUT_PATH> @TAB@ Capture screen and save the file to the host machine",
+        "capture" : "-c, --capture-screen <CAPTURE_FILE> @TAB@ Capture screen and save the file to the host machine",
         "display" : [
             "-dp,--display <DISPLAY_ID> @TAB@ Specify DISPLAY_ID",
             "@TAB@ Use it with capture screen option"
@@ -66,16 +66,16 @@
             "# Display system information",
             "ares-device -i -d DEVICE",
             "",
-            "# Display resource usage with time interval",
-            "ares-device -r -t 1 -d DEVICE",
+            "# Display system resource usage",
+            "ares-device -r -d DEVICE",
             "",
-            "# Display resource usage and save them to a csv file",
-            "ares-device -r -s -d DEVICE",
+            "# Display system resource usage repeatedly and save them to a csv file",
+            "ares-device -r -s resouce.csv -t 1 -d DEVICE",
             "",
-            "# Display resource usage of running app and service",
+            "# Display system resource usage of running app and service",
             "ares-device -r -l -t 3 -d DEVICE",
             "",
-            "# Display resource usage of specified running app",
+            "# Display system resource usage of specified running app",
             "ares-device -r -id com.examples.app -t 5 -d DEVICE",
             "",
             "# Capture the screen of display 1 as screen.png",

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -80,7 +80,7 @@ const log = require('npmlog'),
             "INVALID_OBJECT" : "Object format error",
             "INVALID_MODE" : "Please specify an option, either '--add' or '--modify'",
             "INVALID_CAPTURE_FORMAT" : "Please specify the file extension(.png, .bmp or .jpg)",
-            "INVALID_CSV_FORMAT" : "Please specify the file extension(.csv)",
+            "INVALID_CSV_FORMAT" : "Please change the file extension to .csv",
             "INVALID_COMMAND" : "This command is invalid. Please check the supported commands using ares -l",
             "INVALID_COMBINATION" : "This options cannot be used with display option",
             

--- a/lib/base/error-handler.js
+++ b/lib/base/error-handler.js
@@ -80,6 +80,7 @@ const log = require('npmlog'),
             "INVALID_OBJECT" : "Object format error",
             "INVALID_MODE" : "Please specify an option, either '--add' or '--modify'",
             "INVALID_CAPTURE_FORMAT" : "Please specify the file extension(.png, .bmp or .jpg)",
+            "INVALID_CSV_FORMAT" : "Please specify the file extension(.csv)",
             "INVALID_COMMAND" : "This command is invalid. Please check the supported commands using ares -l",
             "INVALID_COMBINATION" : "This options cannot be used with display option",
             

--- a/lib/device.js
+++ b/lib/device.js
@@ -1299,7 +1299,7 @@ const async = require('async'),
                     // paresBase does not have file extesntion, add .png format
                     options.fileName += "." + csvFormat;
                 } else if (parseExt !== csvFormat) {
-                    return setImmediate(next, errHndl.getErrMsg("INVALID_CSV_FORMAT"));
+                    return next(errHndl.getErrMsg("INVALID_CSV_FORMAT"));
                 }
             } else if(parseDirPath) {
                 // the path has only "directory" without parseBase

--- a/lib/device.js
+++ b/lib/device.js
@@ -234,13 +234,25 @@ const async = require('async'),
             const systemGroup = {};
             systemGroup.initialExecution = true;
             options = options || {};
+            options.destinationPath = "";
+            options.fileName = "";
+            options.csvPath = "";
             async.series([
+                _createOutputPath,
                 _makeSession,
                 _getSystemResouceInfo
             ],  function(err, results) {
                 log.silly("device#systemResource()", "err:", err, ", results:", results);
                 next(err);
             });
+
+            function _createOutputPath(next) {
+                if(options.save && options.csvPath === "") {
+                    makeCSVOutputPath(options, next);
+                } else {
+                    next();
+                }
+            }
 
             function _makeSession(next) {
                 makeSession(options, next);
@@ -299,7 +311,7 @@ const async = require('async'),
                 log.info("device#systemResource()#_callSystemResourceInfoCmd()");
 
                 const wStream = new streamBuffers.WritableStreamBuffer();
-                const cmd = 'date; grep -c ^processor /proc/cpuinfo; grep "cpu *" /proc/stat; free -k';
+                const cmd = 'date "+%Y-%m-%d %H:%M:%S"; grep -c ^processor /proc/cpuinfo; grep "cpu *" /proc/stat; free -k';
                 try {
                     options.session.run(cmd, null, wStream, null, function(err) {
                         if (err) {
@@ -451,10 +463,9 @@ const async = require('async'),
                 const cpuinfo = sysinfo.cpuinfo,
                     meminfo = sysinfo.meminfo,
                     cpuinfoTable = new Table(),
-                    meminfoTable = new Table();
+                    meminfoTable = new Table(),
+                    dataForCSV = [];
 
-                const data = [];
-                let obj = {};
                 // add CPU info to the table
                 for (const key in cpuinfo) {
                     cpuinfoTable.cell('(%)', key );
@@ -465,7 +476,7 @@ const async = require('async'),
                     cpuinfoTable.newRow();
 
                     // Add csv array
-                    obj = {
+                    const obj = {
                         time : sysinfo.date,
                         cpu : key,
                         overall: cpuinfo[key].overall,
@@ -474,7 +485,7 @@ const async = require('async'),
                         others: cpuinfo[key].others
                     };
 
-                    data.push(obj);
+                    dataForCSV.push(obj);
                 }
                 // add memoryInfo to the table
                 for (const key in meminfo) {
@@ -487,56 +498,78 @@ const async = require('async'),
                     meminfoTable.cell('available', meminfo[key].available);
                     meminfoTable.newRow();
 
-                    obj = {
+                    const obj = {
                         time : sysinfo.date,
                         memory : key,
                         total : meminfo[key].total,
                         used: meminfo[key].used,
                         free: meminfo[key].free,
                         shared: meminfo[key].shared,
-                        buff_cache: meminfo[key].buff_cache,
+                        "buff/cache": meminfo[key].buff_cache,
                         available: meminfo[key].available
                     };
-                    data.push(obj);
+                    dataForCSV.push(obj);
                 }
-                
-                console.log(sysinfo.date + "\n");
-                console.log(cpuinfoTable.toString());
-                console.log(meminfoTable.toString());
-                console.log("=================================================================");
+                // write CSV file if user gives --save option
+                if (options.save && options.csvPath) {
+                    // create a directory
+                    if (!fs.existsSync(options.destinationPath)) {
+                        mkdirp(options.destinationPath, function(err) {
+                            if (err) {
+                                return setImmediate(next, errHndl.getErrMsg(err));
+                            }
+                        });
+                    }
+                    // write csv file
+                    // when openMode is false, the new csv file will be created and "Header" add to the file 
+                    let openMode = false;
+                    if (fs.existsSync(options.csvPath)) {
+                        openMode = true;
+                    }
 
-                const outPath = path.join(__dirname, "../bin", "Allout.csv");
-                console.log(outPath);
-                
-                let appendBoolean = false;
-                if (fs.existsSync(outPath)) {
-                    appendBoolean = true;
+                    const csvWriter = createCsvWriter({
+                        path: options.csvPath,
+                        header: [
+                            {id: 'time', title: 'time'},
+                            {id: 'cpu', title: '(%)'},
+                            {id: 'overall', title: 'overall'},
+                            {id: 'usermode', title: 'usermode'},
+                            {id: 'kernelmode', title: 'kernelmode'},
+                            {id: 'others', title: 'others'},
+                            {id: 'memory', title: '(KB)'},
+                            {id: 'total', title: 'total'},
+                            {id: 'used', title: 'used'},
+                            {id: 'free', title: 'free'},
+                            {id: 'shared', title: 'shared'},
+                            {id: 'buff/cache', title: 'buff/cache'},
+                            {id: 'available', title: 'available'}
+                        ],
+                        append : openMode
+                    });
+
+                    csvWriter
+                    .writeRecords(dataForCSV)
+                    .then(function() {
+                        log.silly("device#systemResource()#_printSystemInfo()", "CSV file updated");
+                        // csv file has been created at first
+                        if(openMode === false) {
+                            const resultTxt = "Create " + chalk.green(options.fileName) + " to " + options.destinationPath;
+                            console.log(resultTxt);
+                        }
+                        __printTable();
+                    }).catch(function(err) {
+                        return setImmediate(next, errHndl.getErrMsg(err));
+                    });
+                } else {
+                    __printTable();
                 }
 
-                const csvWriter = createCsvWriter({
-                    path: outPath,
-                    header: [
-                      {id: 'time', title: 'time'},
-                      {id: 'cpu', title: 'cpu'},
-                      {id: 'overall', title: 'overall'},
-                      {id: 'usermode', title: 'usermode'},
-                      {id: 'kernelmode', title: 'kernelmode'},
-                      {id: 'others', title: 'others'},
-                      {id: 'memory', title: 'memory'},
-                      {id: 'total', title: 'total'},
-                      {id: 'used', title: 'used'},
-                      {id: 'free', title: 'free'},
-                      {id: 'shared', title: 'shared'},
-                      {id: 'buff/cache', title: 'buff/cache'},
-                      {id: 'available', title: 'available'},
-                    ], 
-                    append : appendBoolean
-                });
-
-                csvWriter
-                .writeRecords(data)
-                .then(()=> console.log('The CSV file was written successfully'));
-
+                function __printTable() {
+                    console.log(sysinfo.date + "\n");
+                    console.log(cpuinfoTable.toString());
+                    console.log(meminfoTable.toString());
+                    console.log("=================================================================");
+                }
             }
         },
         /**
@@ -551,13 +584,26 @@ const async = require('async'),
             const processGroup = {};
             processGroup.initialExecution = true;
             options = options || {};
+            options.destinationPath = "";
+            options.fileName = "";
+            options.csvPath = "";
+
             async.series([
+                _createOutputPath,
                 _makeSession,
                 _getProcessResouceInfo
             ],  function(err, results) {
                 log.silly("device#processResource()", "err:", err, ", results:", results);
                 next(err);
             });
+
+            function _createOutputPath(next) {
+                if(options.save && options.csvPath === "") {
+                    makeCSVOutputPath(options, next);
+                } else {
+                    next();
+                }
+            }
 
             function _makeSession(next) {
                 makeSession(options, next);
@@ -577,6 +623,7 @@ const async = require('async'),
                                 _callProcessInfoCmd();
                                 repeatCount++;
                                 timerId = setTimeout(repeat, 1000);
+                                options.timerId = timerId;
                             } else {
                                 clearTimeout(timerId);
                                 return next();
@@ -616,7 +663,7 @@ const async = require('async'),
                 log.info("device#processResource()#_callProcessInfoCmd()");
 
                 const wStream = new streamBuffers.WritableStreamBuffer();
-                const cmd = 'date; grep "cpu *" /proc/stat | sed "1d" | awk \'{for (i=0;i<NR;i++){if(i==NR-1){totalSum+=$2+$3+$4+$5+$6+$7+$8+$9+$10+$11;idleSum+=$5}}} END { for (i=0;i<NR;i++){if(i==NR-1){print idleSum;print totalSum}}}\'; cat /proc/[0-9]*/stat; echo \'psList\' ;  ps -ax | sed "1d" | awk \'/ /{print $1 "\t"$5}\'; echo \'serviceStringStart\'; ls /media/developer/apps/usr/palm/services ; echo \'serviceStringEnd\'; luna-send-pub -n 1 -f luna://com.webos.applicationManager/dev/running \'{}\'; grep -c ^processor /proc/cpuinfo';
+                const cmd = 'date "+%Y-%m-%d %H:%M:%S"; grep "cpu *" /proc/stat | sed "1d" | awk \'{for (i=0;i<NR;i++){if(i==NR-1){totalSum+=$2+$3+$4+$5+$6+$7+$8+$9+$10+$11;idleSum+=$5}}} END { for (i=0;i<NR;i++){if(i==NR-1){print idleSum;print totalSum}}}\'; cat /proc/[0-9]*/stat; echo \'psList\' ;  ps -ax | sed "1d" | awk \'/ /{print $1 "\t"$5}\'; echo \'serviceStringStart\'; ls /media/developer/apps/usr/palm/services ; echo \'serviceStringEnd\'; luna-send-pub -n 1 -f luna://com.webos.applicationManager/dev/running \'{}\'; grep -c ^processor /proc/cpuinfo';
                 try {
                     options.session.run(cmd, null, wStream, null, function(err) {
                         if (err) {
@@ -791,7 +838,7 @@ const async = require('async'),
                             const objActApp = arrActiveApps[j],
                                 webprocId = objActApp["webprocessid"],
                                 procId = objActApp["processid"],
-                                displayId = objActApp["displayId"];
+                                displayId = objActApp["displayId"] || 0;
                             let processId;
                             if (webprocId !== "" && webprocId !== undefined && webprocId !== "undefined") {
                                 processId = webprocId;
@@ -994,6 +1041,7 @@ const async = require('async'),
                 
                 const processinfo = processgrpinfo.processinfo,
                     processinfoTable = new Table();
+
                 let found = false;
                 if (options.id) {
                     processinfo.forEach(function(process) {
@@ -1014,7 +1062,7 @@ const async = require('async'),
                 }
 
                 // add process list to table
-                const data = [];
+                const dataForCSV = [];
                 if (Array.isArray(processinfo)) {
                     processinfo.forEach(function(process) {
                         // if user gives ID, print only the ID's information
@@ -1023,10 +1071,7 @@ const async = require('async'),
                         }
                         processinfoTable.cell('PID', process.pid);
                         processinfoTable.cell('ID', process.appid );
-                        // only for ose, print "displayId"
-                        if (process.displayId !== undefined) {
-                            processinfoTable.cell('DISPLAY ID', process.displayId);
-                        }
+                        processinfoTable.cell('DISPLAY ID', process.displayId);
                         processinfoTable.cell('CPU(%)', process.cpu);
 
                         const meminfo = process.memory;
@@ -1034,102 +1079,72 @@ const async = require('async'),
                         processinfoTable.cell('MEMORY(KB)', meminfo.size);
                         processinfoTable.newRow();
 
-                        // Add csv array
+                        // add data object
                         const obj = {
                               time : processgrpinfo.date,
                               pid: process.pid,
                               id: process.appid,
+                              displayId : process.displayId,
                               cpu: process.cpu,
                               memory: meminfo.percent,
                               memory_size: meminfo.size
                         };
-                        data.push(obj);
+                        dataForCSV.push(obj);
                     });
                 }
-                console.log(processgrpinfo.date + "\n");
-                console.log(processinfoTable.toString());
-                console.log("======================================================================"); 
-                
-                
-                if(options.outPath) {
-                    const outInfo = _makeOutputPath(options.outPath);
-                    console.log("outPath!!!" + outInfo.destinationPath, "FileName : ", outInfo.fileName);
-
-                    // creat a directory
-                    if (!fs.existsSync(outInfo.destinationPath)) {
-                        mkdirp.sync(outInfo.destinationPath);
-                    } 
-                    
-                    let appendBoolean = false;
-                    const filePath = path.resolve(outInfo.destinationPath, outInfo.fileName);
-                    if (fs.existsSync(filePath)) {
-                        appendBoolean = true;
+                // write CSV file if user gives --save option
+                if (options.save && options.csvPath) {
+                    // create a directory
+                    if (!fs.existsSync(options.destinationPath)) {
+                        mkdirp(options.destinationPath, function(err) {
+                            if (err) {
+                                return setImmediate(next, errHndl.getErrMsg(err));
+                            }
+                        });
+                    }
+                    // write csv file
+                    // when openMode is false, the new csv file will be created and "Header" add to the file 
+                    let openMode = false;
+                    if (fs.existsSync(options.csvPath)) {
+                        openMode = true;
                     }
                     const csvWriter = createCsvWriter({
-                        path: filePath,
-                        header: [
-                        {id: 'time', title: 'time'},
-                        {id: 'pid', title: 'PID'},
-                        {id: 'id', title: 'ID'},
-                        {id: 'cpu', title: 'CPU(%)'},
-                        {id: 'memory', title: 'MEMORY(%)'},
-                        {id: 'memory_size', title: 'MEMORY(KB)'},
-                        ], 
-                        append : appendBoolean
+                        path: options.csvPath,
+                        header : [
+                            {id: 'time', title: 'TIME'},
+                            {id: 'pid', title: 'PID'},
+                            {id: 'id', title: 'ID'},
+                            {id: 'displayId', title: 'DISPLAY ID'},
+                            {id: 'cpu', title: 'CPU(%)'},
+                            {id: 'memory', title: 'MEMORY(%)'},
+                            {id: 'memory_size', title: 'MEMORY(KB)'}
+                        ],
+                        append : openMode
                     });
 
                     csvWriter
-                    .writeRecords(data)
-                    .then(()=> console.log('The CSV file was written successfully'));
-                }
-            }
-
-            function _makeOutputPath(outputPath) {
-                console.log("device#processResource()#_makeOutputPath()");
-                let fileName = "",
-                    destinationPath = "",
-                    csvFormat = "csv"; // csv is default format
-
-                if (outputPath === null || outputPath === "true") {
-                    fileName += createDateFileName(null, csvFormat);
-                    destinationPath = path.resolve('.');
-                } else {
-                    // get directory path, file path, file Extenstion from given path
-                    const parseDirPath = path.dirname(outputPath),
-                        parseBase = path.parse(outputPath).base;
-
-                    let parseExt = path.parse(outputPath).ext;
-                    parseExt = parseExt.split('.').pop();
-
-                    log.info("device#captureScreen()#_makeCaptureOption()" + "dir name:" + parseDirPath
-                        + " ,file name:" + parseBase + " ,inputFormat:" + parseExt);
-
-                    // if specific path is given
-                    if (parseBase) {
-                        // parseBase is [filename].[ext] format
-                        if (parseExt) {
-                            if (parseExt !== csvFormat) {
-                                return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
-                            }
-                            fileName = parseBase;
-                            destinationPath = path.resolve(parseDirPath);
-                        } else if (parseExt === "") {
-                            // paresBase is directory path. Use it as destination directory path
-                            fileName += createDateFileName(null, csvFormat);
-                            destinationPath = path.resolve(outputPath);
+                    .writeRecords(dataForCSV)
+                    .then(function() {
+                        log.silly("device#systemResource()#_printSystemInfo()", "CSV file updated");
+                        // csv file has been created at first
+                        if(openMode === false) {
+                            const resultTxt = "Create " + chalk.green(options.fileName) + " to " + options.destinationPath;
+                            console.log(resultTxt);
                         }
-                    } else if (parseDirPath) {
-                        // the path has only "directory" without parseBase
-                        // for example, "ares-device -c /" or "ares-defvice -c ."
-                        fileName += createDateFileName(null, csvFormat);
-                        destinationPath = path.resolve(parseDirPath);
-                    }
+                        __printTable();
+                    }).catch(function(err) {
+                        return setImmediate(next, errHndl.getErrMsg(err));
+                    });
+                } else {
+                    __printTable();
                 }
-                const outInfo = {
-                    destinationPath : destinationPath,
-                    fileName: fileName
-                };
-                return outInfo;
+
+                function __printTable() {
+                    // Print resullt to terminal
+                    console.log(processgrpinfo.date + "\n");
+                    console.log(processinfoTable.toString());
+                    console.log("======================================================================");
+                }
             }
         },
         /**
@@ -1289,6 +1304,50 @@ const async = require('async'),
             log.info("device#makeSession()", "already exist session");
             next();
         }
+    }
+
+    function makeCSVOutputPath(options, next) {
+        log.info("device#makeCSVOutputPath()");
+        const csvFormat = "csv"; // csv is default format
+
+        if (options.outputPath === null) {
+            options.fileName = createDateFileName(null, csvFormat);
+            options.destinationPath = path.resolve('.');
+        } else {
+            // get directory path, file path, file Extenstion from given path
+            const parseDirPath = path.dirname(options.outputPath),
+                parseBase = path.parse(options.outputPath).base;
+
+            let parseExt = path.parse(options.outputPath).ext;
+            parseExt = parseExt.split('.').pop();
+
+            log.info("device#captureScreen()#_makeCaptureOption()" + "dir name:" + parseDirPath
+                + " ,file name:" + parseBase + " ,inputFormat:" + parseExt);
+
+            // if specific path is given
+            if (parseBase) {
+                // parseBase is [filename].[ext] format
+                if (parseExt) {
+                    if (parseExt !== csvFormat) {
+                        return next(errHndl.getErrMsg("INVALID_CSV_FORMAT"));
+                    }
+                    options.fileName = parseBase;
+                    options.destinationPath = path.resolve(parseDirPath);
+                } else if (parseExt === "") {
+                    // paresBase is directory path. Use it as destination directory path
+                    options.fileName = createDateFileName(null, csvFormat);
+                    options.destinationPath = path.resolve(options.outputPath);
+                }
+            } else if (parseDirPath) {
+                // the path has only "directory" without parseBase
+                // for example, "ares-device -r -S /" or "ares-defvice -r ."
+                options.fileName = createDateFileName(null, csvFormat);
+                options.destinationPath = path.resolve(parseDirPath);
+            }
+        }
+
+        options.csvPath = path.resolve(options.destinationPath, options.fileName);
+        next();
     }
 
     if (typeof module !== 'undefined' && module.exports) {

--- a/lib/device.js
+++ b/lib/device.js
@@ -1162,9 +1162,10 @@ const async = require('async'),
 
             function _makeCaptureOption(next) {
                 log.info("device#captureScreen()#_makeCaptureOption()");
+
+                const captureFormat = "PNG"; // PNG is default format
                 let captureFileName = options.session.target.name + "_" + "display" + options.display + "_",
-                    destinationPath = "",
-                    captureFormat = "PNG"; // PNG is default format
+                    destinationPath = "";
 
                 if (options.outputPath === null) {
                     captureFileName += createDateFileName(null, captureFormat.toLowerCase());
@@ -1175,27 +1176,23 @@ const async = require('async'),
                         parseBase = path.parse(options.outputPath).base;
 
                     let parseExt = path.parse(options.outputPath).ext;
-                    parseExt = parseExt.split('.').pop();
 
+                    parseExt = parseExt.split('.').pop();
                     log.info("device#captureScreen()#_makeCaptureOption()" + "dir name:" + parseDirPath
                         + " ,file name:" + parseBase + " ,inputFormat:" + parseExt);
 
                     // if specific path is given
                     if (parseBase) {
                         // parseBase is [filename].[ext] format
-                        if (parseExt) {
-                            if (parseExt === "png" || parseExt === "bmp" || parseExt === "jpg") {
-                                captureFormat = parseExt.toUpperCase();
-                            } else {
-                                return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
-                            }
-                            captureFileName = parseBase;
-                            destinationPath = path.resolve(parseDirPath);
-                        } else if (parseExt === "") {
+                        if (parseExt === "") {
                             // paresBase does not have file extesntion, add .png format
                             captureFileName = parseBase + "." + captureFormat.toLowerCase();
-                            destinationPath = path.resolve(parseDirPath);
+                        } else if (parseExt !== "png" && parseExt !== "bmp" && parseExt !== "jpg") {
+                            return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
+                        } else {
+                            captureFileName = parseBase;
                         }
+                        destinationPath = path.resolve(parseDirPath);
                     } else if (parseDirPath) {
                         // the path has only "directory" without parseBase
                         // for example, "ares-device -c /"
@@ -1289,28 +1286,26 @@ const async = require('async'),
                 parseBase = path.parse(options.outputPath).base;
 
             let parseExt = path.parse(options.outputPath).ext;
-            parseExt = parseExt.split('.').pop();
 
+            parseExt = parseExt.split('.').pop();
             log.info("device#captureScreen()#_makeCaptureOption()" + "dir name:" + parseDirPath
                 + " ,file name:" + parseBase + " ,inputFormat:" + parseExt);
 
             // if specific path is given
             if (parseBase) {
                 // parseBase is [filename].[ext] format
-                if (parseExt) {
-                    if (parseExt !== csvFormat) {
-                        return next(errHndl.getErrMsg("INVALID_CSV_FORMAT"));
-                    }
-                    options.fileName = parseBase;
-                    options.destinationPath = path.resolve(parseDirPath);
-                } else if (parseExt === "") {
-                    // paresBase does not have file extesntion, Add .csv format
+                if (parseExt === "") {
+                    // paresBase does not have file extesntion, add .png format
                     options.fileName = parseBase + "." + csvFormat;
-                    options.destinationPath = path.resolve(parseDirPath);
+                } else if (parseExt !== csvFormat) {
+                    return setImmediate(next, errHndl.getErrMsg("INVALID_CSV_FORMAT"));
+                } else {
+                    options.fileName = parseBase;
                 }
+                options.destinationPath = path.resolve(parseDirPath);
             } else if(parseDirPath) {
                 // the path has only "directory" without parseBase
-                // for example, "ares-device -r -S /"
+                // for example, "ares-device -r -s /"
                 options.fileName = createDateFileName(null, csvFormat);
                 options.destinationPath = path.resolve(parseDirPath);
             }

--- a/lib/device.js
+++ b/lib/device.js
@@ -483,7 +483,6 @@ const async = require('async'),
                         kernelmode: cpuinfo[key].kernelmode,
                         others: cpuinfo[key].others
                     };
-
                     dataForCSV.push(obj);
                 }
                 // add memoryInfo to the table
@@ -614,7 +613,6 @@ const async = require('async'),
                                 _callProcessInfoCmd();
                                 repeatCount++;
                                 timerId = setTimeout(repeat, 1000);
-                                options.timerId = timerId;
                             } else {
                                 clearTimeout(timerId);
                                 return next();

--- a/lib/device.js
+++ b/lib/device.js
@@ -8,7 +8,6 @@ const async = require('async'),
     chalk = require('chalk'),
     createCsvWriter = require('csv-writer').createObjectCsvWriter,
     fs = require('fs'),
-    mkdirp = require('mkdirp'),
     npmlog = require('npmlog'),
     path = require('path'),
     streamBuffers = require('stream-buffers'),
@@ -512,14 +511,6 @@ const async = require('async'),
                 }
                 // write CSV file if user gives --save option
                 if (options.save && options.csvPath) {
-                    // create a directory
-                    if (!fs.existsSync(options.destinationPath)) {
-                        mkdirp(options.destinationPath, function(err) {
-                            if (err) {
-                                return setImmediate(next, errHndl.getErrMsg(err));
-                            }
-                        });
-                    }
                     // write csv file
                     // when openMode is false, the new csv file will be created and "Header" add to the file 
                     let openMode = false;
@@ -1094,14 +1085,6 @@ const async = require('async'),
                 }
                 // write CSV file if user gives --save option
                 if (options.save && options.csvPath) {
-                    // create a directory
-                    if (!fs.existsSync(options.destinationPath)) {
-                        mkdirp(options.destinationPath, function(err) {
-                            if (err) {
-                                return setImmediate(next, errHndl.getErrMsg(err));
-                            }
-                        });
-                    }
                     // write csv file
                     // when openMode is false, the new csv file will be created and "Header" add to the file 
                     let openMode = false;
@@ -1211,14 +1194,14 @@ const async = require('async'),
                             captureFileName = parseBase;
                             destinationPath = path.resolve(parseDirPath);
                         } else if (parseExt === "") {
-                            // paresBase is directory path. Use it as destination directory path
-                            captureFileName += createDateFileName(null, captureFormat.toLowerCase());
-                            destinationPath = path.resolve(options.outputPath);
+                            // paresBase does not have file extesntion, add .png format
+                            captureFileName = parseBase + "." + captureFormat.toLowerCase();
+                            destinationPath = path.resolve(parseDirPath);
                         }
                     } else if (parseDirPath) {
                         // the path has only "directory" without parseBase
-                        // for example, "ares-device -c /" or "ares-defvice -c ."
-                        captureFileName += createDateFileName(null, captureFormat.toLowerCase());
+                        // for example, "ares-device -c /"
+                        captureFileName = createDateFileName(null, captureFormat.toLowerCase());
                         destinationPath = path.resolve(parseDirPath);
                     }
                 }
@@ -1267,17 +1250,7 @@ const async = require('async'),
 
             function _copyFileToLocal(next) {
                 log.info("device#captureScreen()#_copyFileToLocal()");
-                if (!fs.existsSync(options.destinationPath)) {
-                    mkdirp(options.destinationPath, function(err) {
-                        if (err) {
-                            return setImmediate(next, errHndl.getErrMsg(err));
-                        } else {
-                            pullLib.pull(options, next);
-                        }
-                    });
-                } else {
-                    pullLib.pull(options, next);
-                }
+                pullLib.pull(options, next);
             }
 
             function _removeTmpDir(next) {
@@ -1307,7 +1280,6 @@ const async = require('async'),
     }
 
     function makeCSVOutputPath(options, next) {
-        log.info("device#makeCSVOutputPath()");
         const csvFormat = "csv"; // csv is default format
 
         if (options.outputPath === null) {
@@ -1334,19 +1306,23 @@ const async = require('async'),
                     options.fileName = parseBase;
                     options.destinationPath = path.resolve(parseDirPath);
                 } else if (parseExt === "") {
-                    // paresBase is directory path. Use it as destination directory path
-                    options.fileName = createDateFileName(null, csvFormat);
-                    options.destinationPath = path.resolve(options.outputPath);
+                    // paresBase does not have file extesntion, Add .csv format
+                    options.fileName = parseBase + "." + csvFormat;
+                    options.destinationPath = path.resolve(parseDirPath);
                 }
-            } else if (parseDirPath) {
+            } else if(parseDirPath) {
                 // the path has only "directory" without parseBase
-                // for example, "ares-device -r -S /" or "ares-defvice -r ."
+                // for example, "ares-device -r -S /"
                 options.fileName = createDateFileName(null, csvFormat);
                 options.destinationPath = path.resolve(parseDirPath);
             }
         }
 
         options.csvPath = path.resolve(options.destinationPath, options.fileName);
+        if (fs.existsSync(options.csvPath)) {
+            fs.unlinkSync(options.csvPath);
+        }
+        log.info("device#makeCSVOutputPath()", "csvPath:", options.csvPath);
         next();
     }
 

--- a/lib/device.js
+++ b/lib/device.js
@@ -6,6 +6,7 @@
 
 const async = require('async'),
     chalk = require('chalk'),
+    createCsvWriter = require('csv-writer').createObjectCsvWriter,
     fs = require('fs'),
     mkdirp = require('mkdirp'),
     npmlog = require('npmlog'),
@@ -452,6 +453,8 @@ const async = require('async'),
                     cpuinfoTable = new Table(),
                     meminfoTable = new Table();
 
+                const data = [];
+                let obj = {};
                 // add CPU info to the table
                 for (const key in cpuinfo) {
                     cpuinfoTable.cell('(%)', key );
@@ -460,6 +463,18 @@ const async = require('async'),
                     cpuinfoTable.cell('kernelmode', cpuinfo[key].kernelmode);
                     cpuinfoTable.cell('others', cpuinfo[key].others);
                     cpuinfoTable.newRow();
+
+                    // Add csv array
+                    obj = {
+                        time : sysinfo.date,
+                        cpu : key,
+                        overall: cpuinfo[key].overall,
+                        usermode: cpuinfo[key].usermode,
+                        kernelmode: cpuinfo[key].kernelmode,
+                        others: cpuinfo[key].others
+                    };
+
+                    data.push(obj);
                 }
                 // add memoryInfo to the table
                 for (const key in meminfo) {
@@ -471,11 +486,57 @@ const async = require('async'),
                     meminfoTable.cell('buff/cache', meminfo[key].buff_cache);
                     meminfoTable.cell('available', meminfo[key].available);
                     meminfoTable.newRow();
+
+                    obj = {
+                        time : sysinfo.date,
+                        memory : key,
+                        total : meminfo[key].total,
+                        used: meminfo[key].used,
+                        free: meminfo[key].free,
+                        shared: meminfo[key].shared,
+                        buff_cache: meminfo[key].buff_cache,
+                        available: meminfo[key].available
+                    };
+                    data.push(obj);
                 }
+                
                 console.log(sysinfo.date + "\n");
                 console.log(cpuinfoTable.toString());
                 console.log(meminfoTable.toString());
                 console.log("=================================================================");
+
+                const outPath = path.join(__dirname, "../bin", "Allout.csv");
+                console.log(outPath);
+                
+                let appendBoolean = false;
+                if (fs.existsSync(outPath)) {
+                    appendBoolean = true;
+                }
+
+                const csvWriter = createCsvWriter({
+                    path: outPath,
+                    header: [
+                      {id: 'time', title: 'time'},
+                      {id: 'cpu', title: 'cpu'},
+                      {id: 'overall', title: 'overall'},
+                      {id: 'usermode', title: 'usermode'},
+                      {id: 'kernelmode', title: 'kernelmode'},
+                      {id: 'others', title: 'others'},
+                      {id: 'memory', title: 'memory'},
+                      {id: 'total', title: 'total'},
+                      {id: 'used', title: 'used'},
+                      {id: 'free', title: 'free'},
+                      {id: 'shared', title: 'shared'},
+                      {id: 'buff/cache', title: 'buff/cache'},
+                      {id: 'available', title: 'available'},
+                    ], 
+                    append : appendBoolean
+                });
+
+                csvWriter
+                .writeRecords(data)
+                .then(()=> console.log('The CSV file was written successfully'));
+
             }
         },
         /**
@@ -683,9 +744,9 @@ const async = require('async'),
                                 otherList.push(objOther);
                         } else {
                             tempProcGrps[grpname]["pid"] = pid;
-                            tempProcGrps[grpname]["cputime"]+= cputime;
-                            tempProcGrps[grpname]["RSS"]+= rss;
-                            tempProcGrps[grpname]["pmem"]+= pmem;
+                            tempProcGrps[grpname]["cputime"] += cputime;
+                            tempProcGrps[grpname]["RSS"] += rss;
+                            tempProcGrps[grpname]["pmem"] += pmem;
                         }
                     }
                     // get the Children of Service
@@ -700,9 +761,9 @@ const async = require('async'),
                                 continue;
                             }
                             tempProcGrps[attrName]["pid"] = otherList[i]["pid"];
-                            tempProcGrps[attrName]["cputime"]+= otherList[i]["cputime"];
-                            tempProcGrps[attrName]["RSS"]+= otherList[i]["RSS"];
-                            tempProcGrps[attrName]["pmem"]+= otherList[i]["pmem"];
+                            tempProcGrps[attrName]["cputime"] += otherList[i]["cputime"];
+                            tempProcGrps[attrName]["RSS"] += otherList[i]["RSS"];
+                            tempProcGrps[attrName]["pmem"] += otherList[i]["pmem"];
                             otherList.splice(i, 1);
                             i--;
                         }
@@ -756,7 +817,7 @@ const async = require('async'),
                                 let webpcpuval = ((pcputime - processGroup[prevcpuTime]) * 100/(totalCPUtime - processGroup.prevTotalcputime));
                                 // restrict showing the negative % values by making lowest to be zero.
                                 if (webpcpuval < 0 || webpcpuval === undefined || isNaN(webpcpuval)) webpcpuval = 0;
-                                    aggcpuVal+= webpcpuval;
+                                    aggcpuVal += webpcpuval;
                                     const groupListAppKey = objActApp["id"]+ "-" + appid;
                                     groupObjList[groupListAppKey] = {
                                         "id" : objActApp["id"],
@@ -844,7 +905,7 @@ const async = require('async'),
                             }
                             // restrict showing the negative % values by making lowest to be zero.
                             if (tempPcpuval < 0 || tempPcpuval === undefined || isNaN(tempPcpuval)) tempPcpuval = 0;
-                            aggcpuVal+= tempPcpuval;
+                            aggcpuVal += tempPcpuval;
                             // system = overallCpuOccupation - (Service used + dynamic apps used);
                             if (processName === "System") {
                                 tempPcpuval = overallCpuOccupation - aggcpuVal;
@@ -930,7 +991,7 @@ const async = require('async'),
             
             function _printProcessList(processgrpinfo) {
                 log.info("device#processResource()#_printProcessList()",  JSON.stringify(processgrpinfo));
-
+                
                 const processinfo = processgrpinfo.processinfo,
                     processinfoTable = new Table();
                 let found = false;
@@ -953,6 +1014,7 @@ const async = require('async'),
                 }
 
                 // add process list to table
+                const data = [];
                 if (Array.isArray(processinfo)) {
                     processinfo.forEach(function(process) {
                         // if user gives ID, print only the ID's information
@@ -971,11 +1033,103 @@ const async = require('async'),
                         processinfoTable.cell('MEMORY(%)', meminfo.percent);
                         processinfoTable.cell('MEMORY(KB)', meminfo.size);
                         processinfoTable.newRow();
+
+                        // Add csv array
+                        const obj = {
+                              time : processgrpinfo.date,
+                              pid: process.pid,
+                              id: process.appid,
+                              cpu: process.cpu,
+                              memory: meminfo.percent,
+                              memory_size: meminfo.size
+                        };
+                        data.push(obj);
                     });
                 }
                 console.log(processgrpinfo.date + "\n");
                 console.log(processinfoTable.toString());
-                console.log("======================================================================");  
+                console.log("======================================================================"); 
+                
+                
+                if(options.outPath) {
+                    const outInfo = _makeOutputPath(options.outPath);
+                    console.log("outPath!!!" + outInfo.destinationPath, "FileName : ", outInfo.fileName);
+
+                    // creat a directory
+                    if (!fs.existsSync(outInfo.destinationPath)) {
+                        mkdirp.sync(outInfo.destinationPath);
+                    } 
+                    
+                    let appendBoolean = false;
+                    const filePath = path.resolve(outInfo.destinationPath, outInfo.fileName);
+                    if (fs.existsSync(filePath)) {
+                        appendBoolean = true;
+                    }
+                    const csvWriter = createCsvWriter({
+                        path: filePath,
+                        header: [
+                        {id: 'time', title: 'time'},
+                        {id: 'pid', title: 'PID'},
+                        {id: 'id', title: 'ID'},
+                        {id: 'cpu', title: 'CPU(%)'},
+                        {id: 'memory', title: 'MEMORY(%)'},
+                        {id: 'memory_size', title: 'MEMORY(KB)'},
+                        ], 
+                        append : appendBoolean
+                    });
+
+                    csvWriter
+                    .writeRecords(data)
+                    .then(()=> console.log('The CSV file was written successfully'));
+                }
+            }
+
+            function _makeOutputPath(outputPath) {
+                console.log("device#processResource()#_makeOutputPath()");
+                let fileName = "",
+                    destinationPath = "",
+                    csvFormat = "csv"; // csv is default format
+
+                if (outputPath === null || outputPath === "true") {
+                    fileName += createDateFileName(null, csvFormat);
+                    destinationPath = path.resolve('.');
+                } else {
+                    // get directory path, file path, file Extenstion from given path
+                    const parseDirPath = path.dirname(outputPath),
+                        parseBase = path.parse(outputPath).base;
+
+                    let parseExt = path.parse(outputPath).ext;
+                    parseExt = parseExt.split('.').pop();
+
+                    log.info("device#captureScreen()#_makeCaptureOption()" + "dir name:" + parseDirPath
+                        + " ,file name:" + parseBase + " ,inputFormat:" + parseExt);
+
+                    // if specific path is given
+                    if (parseBase) {
+                        // parseBase is [filename].[ext] format
+                        if (parseExt) {
+                            if (parseExt !== csvFormat) {
+                                return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
+                            }
+                            fileName = parseBase;
+                            destinationPath = path.resolve(parseDirPath);
+                        } else if (parseExt === "") {
+                            // paresBase is directory path. Use it as destination directory path
+                            fileName += createDateFileName(null, csvFormat);
+                            destinationPath = path.resolve(outputPath);
+                        }
+                    } else if (parseDirPath) {
+                        // the path has only "directory" without parseBase
+                        // for example, "ares-device -c /" or "ares-defvice -c ."
+                        fileName += createDateFileName(null, csvFormat);
+                        destinationPath = path.resolve(parseDirPath);
+                    }
+                }
+                const outInfo = {
+                    destinationPath : destinationPath,
+                    fileName: fileName
+                };
+                return outInfo;
             }
         },
         /**

--- a/lib/device.js
+++ b/lib/device.js
@@ -247,7 +247,7 @@ const async = require('async'),
             });
 
             function _createOutputPath(next) {
-                if(options.save && options.csvPath === "") {
+                if (options.save && options.csvPath === "") {
                     makeCSVOutputPath(options, next);
                 } else {
                     next();
@@ -552,7 +552,7 @@ const async = require('async'),
                     .then(function() {
                         log.silly("device#systemResource()#_printSystemInfo()", "CSV file updated");
                         // csv file has been created at first
-                        if(openMode === false) {
+                        if (openMode === false) {
                             const resultTxt = "Create " + chalk.green(options.fileName) + " to " + options.destinationPath;
                             console.log(resultTxt);
                         }
@@ -598,7 +598,7 @@ const async = require('async'),
             });
 
             function _createOutputPath(next) {
-                if(options.save && options.csvPath === "") {
+                if (options.save && options.csvPath === "") {
                     makeCSVOutputPath(options, next);
                 } else {
                     next();
@@ -753,7 +753,7 @@ const async = require('async'),
                     let strActiveApps = "",
                         objActiveApps;
                     for (let i = appStartIndex; i < appEndIndex; i++) {
-                        strActiveApps+= allvalues[i];
+                        strActiveApps += allvalues[i];
                     }
                     try {
                         objActiveApps = JSON.parse(strActiveApps);
@@ -1038,7 +1038,7 @@ const async = require('async'),
             
             function _printProcessList(processgrpinfo) {
                 log.info("device#processResource()#_printProcessList()",  JSON.stringify(processgrpinfo));
-                
+
                 const processinfo = processgrpinfo.processinfo,
                     processinfoTable = new Table();
 
@@ -1125,9 +1125,9 @@ const async = require('async'),
                     csvWriter
                     .writeRecords(dataForCSV)
                     .then(function() {
-                        log.silly("device#systemResource()#_printSystemInfo()", "CSV file updated");
+                        log.silly("device#processResource()#_printProcessList()", "CSV file updated");
                         // csv file has been created at first
-                        if(openMode === false) {
+                        if (openMode === false) {
                             const resultTxt = "Create " + chalk.green(options.fileName) + " to " + options.destinationPath;
                             console.log(resultTxt);
                         }

--- a/lib/device.js
+++ b/lib/device.js
@@ -1183,16 +1183,15 @@ const async = require('async'),
 
                     // if specific path is given
                     if (parseBase) {
+                        captureFileName = parseBase;
+                        destinationPath = path.resolve(parseDirPath);
                         // parseBase is [filename].[ext] format
                         if (parseExt === "") {
                             // paresBase does not have file extesntion, add .png format
-                            captureFileName = parseBase + "." + captureFormat.toLowerCase();
+                            captureFileName += "." + captureFormat.toLowerCase();
                         } else if (parseExt !== "png" && parseExt !== "bmp" && parseExt !== "jpg") {
-                            return setImmediate(next, errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
-                        } else {
-                            captureFileName = parseBase;
+                            return next(errHndl.getErrMsg("INVALID_CAPTURE_FORMAT"));
                         }
-                        destinationPath = path.resolve(parseDirPath);
                     } else if (parseDirPath) {
                         // the path has only "directory" without parseBase
                         // for example, "ares-device -c /"
@@ -1293,16 +1292,15 @@ const async = require('async'),
 
             // if specific path is given
             if (parseBase) {
+                options.fileName = parseBase;
+                options.destinationPath = path.resolve(parseDirPath);
                 // parseBase is [filename].[ext] format
                 if (parseExt === "") {
                     // paresBase does not have file extesntion, add .png format
-                    options.fileName = parseBase + "." + csvFormat;
+                    options.fileName += "." + csvFormat;
                 } else if (parseExt !== csvFormat) {
                     return setImmediate(next, errHndl.getErrMsg("INVALID_CSV_FORMAT"));
-                } else {
-                    options.fileName = parseBase;
                 }
-                options.destinationPath = path.resolve(parseDirPath);
             } else if(parseDirPath) {
                 // the path has only "directory" without parseBase
                 // for example, "ares-device -r -s /"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -708,6 +708,11 @@
         }
       }
     },
+    "csv-writer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
+      "integrity": "sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g=="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chalk": "1.1.3",
     "chardet": "0.8.0",
     "combined-stream": "1.0.8",
+    "csv-writer": "1.6.0",
     "easy-table": "1.1.1",
     "elfy": "1.0.0",
     "encoding": "0.1.13",

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -11,7 +11,7 @@ const exec = require('child_process').exec,
 
 const dateFileReg = new RegExp("[A-Za-z0-9]*_display[0-9]_[0-9]*.png"),
     csvFileReg = new RegExp("[0-9]*.csv"),
-    csvFilePath = path.join(__dirname, "..", "tempFiles", "csvDir.csv");
+    csvFilePath = path.join(__dirname, "..", "tempFiles", "resource.csv");
 
 const aresCmd = 'ares-device';
 
@@ -88,7 +88,7 @@ describe(aresCmd, function() {
 describe(aresCmd, function() {
     it('Retrieve session information', function(done) {
         const keys = ["sessionId", "displayId"];
-        exec(cmd + ` -s ${options.device}`, function (error, stdout, stderr) {
+        exec(cmd + ` -sn ${options.device}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
                 expect(stderr).toContain("ares-device ERR! [com.webos.service.sessionmanager failure]: " +
@@ -144,13 +144,12 @@ describe(aresCmd + ' --resource-monitor(-r)', function() {
     });
 
     it('Save specific csv file for all system resource', function(done) {
-        exec(cmd + ` -r -S ${csvFilePath}`, function (error, stdout, stderr) {
+        exec(cmd + ` -r -s ${csvFilePath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
             else {
                 expect(stdout).toContain("cpu0");
-                expect(stdout).toContain(csvFilePath);
                 expect(fs.existsSync(csvFilePath)).toBe(true);
                 done();
             }
@@ -158,7 +157,7 @@ describe(aresCmd + ' --resource-monitor(-r)', function() {
     });
 
     it('Save generated csv file name for all system resource', function(done) {
-        exec(cmd + ` -r -S`, function (error, stdout, stderr) {
+        exec(cmd + ` -r -s`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
@@ -282,13 +281,12 @@ describe(aresCmd + ' --resource-monitor(-r)', function() {
     });
 
     it('Save csv file for specific app resource', function(done) {
-        exec(cmd + ` -r -id ${options.pkgId} -S ${csvFilePath}`, function (error, stdout, stderr) {
+        exec(cmd + ` -r -id ${options.pkgId} -s ${csvFilePath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
             }
             else {
                 expect(stdout).toContain(options.pkgId);
-                expect(stdout).toContain(csvFilePath);
                 expect(fs.existsSync(csvFilePath)).toBe(true);
                 done();
             }
@@ -372,7 +370,7 @@ describe(aresCmd + ' --capture-screen(-c)', function() {
 
 describe(aresCmd + ' negative TC', function() {
     it('Monitor system resource with invalid file extensiton', function(done) {
-        exec(cmd + ` -r -S test.abc`, function (error, stdout, stderr) {
+        exec(cmd + ` -r -s test.abc`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
                 expect(stderr).toContain("ares-device ERR! [Tips]: Please specify the file extension(.csv)");
@@ -382,7 +380,7 @@ describe(aresCmd + ' negative TC', function() {
     });
 
     it('Monitor system resource with invalid destiation Path', function(done) {
-        exec(cmd + ` -r -S invalid/system.csv`, function (error, stdout, stderr) {
+        exec(cmd + ` -r -s invalid/system.csv`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
                 expect(stderr).toContain("ares-device ERR! [syscall failure]: ENOENT: no such file or directory");

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -23,8 +23,14 @@ beforeAll(function (done) {
     common.getOptions()
     .then(function(result){
         options = result;
+        common.removeOutDir(csvFilePath);
         done();
     });
+});
+
+afterAll(function(done) {
+    common.removeOutDir(csvFilePath);
+    done();
 });
 
 describe(aresCmd + ' -v', function() {
@@ -88,7 +94,7 @@ describe(aresCmd, function() {
 describe(aresCmd, function() {
     it('Retrieve session information', function(done) {
         const keys = ["sessionId", "displayId"];
-        exec(cmd + ` -sn ${options.device}`, function (error, stdout, stderr) {
+        exec(cmd + ` -se ${options.device}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
                 expect(stderr).toContain("ares-device ERR! [com.webos.service.sessionmanager failure]: " +
@@ -120,11 +126,23 @@ describe(aresCmd, function() {
     });
 });
 
-describe(aresCmd + ' --resource-monitor(-r)', function() {
-    beforeAll(function(done) {
-        common.removeOutDir(csvFilePath);
-        done();
+describe(aresCmd, function() {
+    const launchCmd = common.makeCmd('ares-launch');
+    it('Launch sample App', function(done) {
+        exec(launchCmd + ` ${options.pkgId}`, function (error, stdout, stderr) {
+            if (stderr && stderr.length > 0) {
+                common.detectNodeMessage(stderr);
+            }
+            expect(stdout).toContain("[Info] Set target device : " + options.device);
+            expect(stdout).toContain(`Launched application ${options.pkgId}`, error);
+            setTimeout(function(){
+                done();
+            }, 3000);
+        });
     });
+});
+
+describe(aresCmd + ' --resource-monitor(-r)', function() {
     afterAll(function(done) {
         common.removeOutDir(csvFilePath);
         done();
@@ -201,32 +219,7 @@ describe(aresCmd + ' --resource-monitor(-r)', function() {
     });
 });
 
-describe(aresCmd, function() {
-    const launchCmd = common.makeCmd('ares-launch');
-    it('Launch sample App', function(done) {
-        exec(launchCmd + ` ${options.pkgId}`, function (error, stdout, stderr) {
-            if (stderr && stderr.length > 0) {
-                common.detectNodeMessage(stderr);
-            }
-            expect(stdout).toContain("[Info] Set target device : " + options.device);
-            expect(stdout).toContain(`Launched application ${options.pkgId}`, error);
-            setTimeout(function(){
-                done();
-            }, 3000);
-        });
-    });
-});
-
 describe(aresCmd + ' --resource-monitor(-r)', function() {
-    beforeAll(function(done) {
-        common.removeOutDir(csvFilePath);
-        done();
-    });
-    afterAll(function(done) {
-        common.removeOutDir(csvFilePath);
-        done();
-    });
-
     it('Print running app resource', function(done) {
         exec(cmd + " -r --list", function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
@@ -373,7 +366,7 @@ describe(aresCmd + ' negative TC', function() {
         exec(cmd + ` -r -s test.abc`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);
-                expect(stderr).toContain("ares-device ERR! [Tips]: Please specify the file extension(.csv)");
+                expect(stderr).toContain("ares-device ERR! [Tips]: Please change the file extension to .csv");
             }
             done();
         });

--- a/spec/jsSpecs/ares-device.spec.js
+++ b/spec/jsSpecs/ares-device.spec.js
@@ -434,7 +434,7 @@ describe(aresCmd + ' negative TC', function() {
         });
     });
 
-    it('Capture with invalid destiation Path', function(done) {
+    it('Monitor system resource with invalid destiation Path', function(done) {
         exec(cmd + ` -r -S ${noPermDirPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
                 common.detectNodeMessage(stderr);


### PR DESCRIPTION
:Release Notes:
Support save options for resource-monitor

:Detailed Notes:
- Add --save(-s) option to save resource usage result to .csv file
- Add --id-filter(-id) option for app or service ID
- Hide --session-information from ares-device help
- Add csv-wirter npm module to package.json
- Update help file
- Add related TC


:Testing Performed:
1. Pass unit test on ose
2. Pass eslint
3. Check the generated csv file with resource-monitor options
$ ares-device -r -s -t 1
$ ares-device -r -s result.csv -t 1
$ ares-device -r -l -t 1 -s
$ ares-device -r -id com.domain.app -t 1 -s
$ ares-device -r -s test.abc -t 1 // error case
$ ares-device -r -s invalid/test.csv // error case

:Issues Addressed:
[WRN-9484] Implement ares-device -r --save option