### PR TITLE
Update version 2.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Command Line Interface for development webOS application and service",
   "main": "./bin/ares.js",
   "author": "ye.kim",


### PR DESCRIPTION
:Release Notes:
Update version 2.3.1

:Detailed Notes:
For synchronize with npm, update version to 2.3.1

:Testing Performed:
1. Install CLI 2.3.1 package using below command
  $ sudo npm uninstall -g @webosose/ares-cli
  $ sudo npm install -g https://github.com:webosose/ares-cli.git#Update_version_2.3.1
2. Check version using below command
  $ ares -V
   > Version: 2.3.1

:Issues Addressed:
[WRN-15707] Prepare to release CLI v2.3.0