### PR TITLE
Support ares-generate to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,16 @@
+const {promisify} = require('util'),
+    aresLauncher = require('./lib/launch'),
+    aresGenerator = require('./lib/generator');
+
+const Launcher = {
+    launch: promisify(aresLauncher.launch),
+    close: promisify(aresLauncher.close),
+    listRunningApp: promisify(aresLauncher.listRunningApp)
+};
+
+const Generator = new aresGenerator();
+
+module.exports = {
+    Launcher,
+    Generator
+};

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -16,28 +16,22 @@ const promise = require('bluebird'),
     readJsonSync = require('./util/json').readJsonSync,
     merge = require('./util/merge');
 
-function Generator(tmplFile) {
-    let templates;
+const templatePath = path.join(__dirname, '/../files/conf/', 'template.json');
+let templates;
 
-    function _setTemplates(_tmplFile) {
-        if (tmplFile) {
-            const cliPath = path.join(__dirname, '..');
-            let contents = fs.readFileSync(_tmplFile);
-            contents = contents.toString().replace(/\$cli-root/gi, cliPath).replace(/\\/g,'/');
-            templates = JSON.parse(contents);
-        } else {
-            templates = null;
-        }
+function Generator() {
+    if (templatePath) {
+        const cliPath = path.join(__dirname, '..');
+        let contents = fs.readFileSync(templatePath);
+        contents = contents.toString().replace(/\$cli-root/gi, cliPath).replace(/\\/g,'/');
+        templates = JSON.parse(contents);
+    } else {
+        templates = null;
     }
-    _setTemplates(tmplFile);
-    this.setTmplates = _setTemplates;
-    this.getTemplates = function() {
-        return templates;
-    };
 }
 
-Generator.prototype.showTemplates = function(listType) {
-    const templates = this.getTemplates(),
+Generator.prototype.showTemplates = function(listType, next) {
+    const templateList = this.getTmpl(),
         table = new Table(),
         _displayType = {
             "webapp": "Web App",
@@ -55,82 +49,89 @@ Generator.prototype.showTemplates = function(listType) {
             "qmlappinfo": "QML App Info"
         };
 
-    for (const name in templates) {
-        if (templates[name].hide === true || !templates[name].type) {
+    for (const name in templateList) {
+        if (templateList[name].hide === true || !templateList[name].type) {
             continue;
         }
-        const isDefault = (templates[name].default) ? "(default) " : "",
-            branch = templates[name].branch || '-',
-            type = _displayType[templates[name].type] || templates[name].type;
+        const isDefault = (templateList[name].default) ? "(default) " : "",
+            type = _displayType[templateList[name].type] || templateList[name].type;
 
         if (listType && ["true", "false", true, false].indexOf(listType) === -1) {
-            if (templates[name].type &&
-                (templates[name].type.match(new RegExp(listType+"$","gi")) === null)) {
+            if (templateList[name].type &&
+                (templateList[name].type.match(new RegExp(listType+"$","gi")) === null)) {
                 continue;
             }
         }
         table.cell('ID', name);
         table.cell('Project Type', type);
-        table.cell('Version', branch);
-        table.cell('Description', isDefault + templates[name].description);
+        table.cell('Description', isDefault + templateList[name].description);
         table.newRow();
     }
-    console.log(table.print());
-    return;
+    return next(null, {msg: table.toString()});
 };
 
-Generator.prototype.existOutDir = function(outDir) {
-    log.verbose("generator#existOutDir()", outDir);
-    try {
-        const files = fs.readdirSync(outDir);
-        if (files.length > 0)
-            return true;
-    } catch (err) {
-        if (err && err.code === 'ENOTDIR') {
-            throw errHndl.getErrMsg("NOT_DIRTYPE_PATH", outDir);
-        }
-        if (err && err.code === 'ENOENT') {
-            log.verbose("generator#generate()", "The directory does not exist.");
-            return false;
-        }
-        throw err;
+Generator.prototype.generate = function(options, next) {
+    // For API
+    if (!options.tmplName) {
+        return next(errHndl.getErrMsg("EMPTY_VALUE", "TEMPLATE"));
     }
-};
+    if (!options.out) {
+        return next(errHndl.getErrMsg("EMPTY_VALUE", "APP_DIR"));
+    }
 
-Generator.prototype.generate = function(options) {
     const tmplName = options.tmplName,
-        pkginfo = options.pkginfo,
-        svcinfo = options.svcinfo,
+        pkginfo = options.pkginfo || {},
+        svcinfo = options.svcinfo || {},
         svcName = options.svcName,
         out = options.out,
-        templates = this.getTemplates(),
         dest = path.resolve(out),
-        template = templates[tmplName];
-    let appinfo = options.appinfo;
+        existDir = this.existOutDir(dest),
+        templateList = this.getTmpl(),
+        template = templateList[tmplName];
+    let appinfo = options.appinfo || {};
 
+    // For API
     if (!template) {
-        return promise.reject(errHndl.getErrMsg("INVALID_TEMPLATE"));
+        return next(errHndl.getErrMsg("INVALID_VALUE", "TEMPLATE", options.tmplName));
+    }
+    if (!options.overwrite && existDir) {
+        return next(errHndl.getErrMsg("NOT_OVERWRITE_DIR", dest));
     }
 
     if (template.metadata && template.metadata.data && typeof template.metadata.data === 'object') {
         appinfo = merge(appinfo, template.metadata.data);
     }
 
-    if (svcName) {
-        svcinfo.id = svcName;
-        svcinfo.services = [{
-            "name": svcName
-        }];
-    } else if (!svcName && !!svcinfo.id) {
-        svcinfo.services = [{
-            "name": svcinfo.id
-        }];
-    }
+    promise.resolve()
+        .then(function() {
+            // If props is not exist, this input from query-mode
+            // If props is exist, this input from props
+            // Check argv.query, argv["no-query"], options.props and conditional statement.
+            if (template.type.match(/(app$|appinfo$)/)) {
+                parsePropArgs(options.props, appinfo);
+            } else if (template.type.match(/(service$|serviceinfo$)/)) {
+                parsePropArgs(options.props, svcinfo);
+            } else if (template.type.match(/(package$|packageinfo$)/)) {
+                parsePropArgs(options.props, pkginfo);
+            }
+        })
+        .then(function() {
+            if (svcName) {
+                svcinfo.id = svcName;
+                svcinfo.services = [{
+                    "name": svcName
+                }];
+            } else if (!svcName && svcinfo && !!svcinfo.id) {
+                svcinfo.services = [{
+                    "name": svcinfo.id
+                }];
+            }
+        });
 
     return promise.resolve()
         .then(function() {
             log.info("generator#generate()", "template name:" + tmplName);
-            console.log("Generating " + tmplName + " in " + dest);
+            next(null, {msg: "Generating " + tmplName + " in " + dest});
 
             let srcs;
             if (tmplName.match(/(^hosted)/)) {
@@ -141,7 +142,7 @@ Generator.prototype.generate = function(options) {
                     let metaTmpl;
                     let url;
                     if (template.metadata && template.metadata.id) {
-                        metaTmpl = templates[template.metadata.id];
+                        metaTmpl = templateList[template.metadata.id];
                     }
                     if (metaTmpl) {
                         if (appinfo.url) {
@@ -162,7 +163,7 @@ Generator.prototype.generate = function(options) {
                 })).then(function() {
                     let metaTmpl;
                     if (template.metadata && template.metadata.id) {
-                        metaTmpl = templates[template.metadata.id];
+                        metaTmpl = templateList[template.metadata.id];
                     }
                     if (metaTmpl) {
                         if (appinfo.id) {
@@ -184,7 +185,7 @@ Generator.prototype.generate = function(options) {
                 })).then(function() {
                     let metaTmpl;
                     if (template.metadata && template.metadata.id) {
-                        metaTmpl = templates[template.metadata.id];
+                        metaTmpl = templateList[template.metadata.id];
                     }
                     if (metaTmpl) {
                         return _writeMetadata(metaTmpl, appinfo, svcinfo, pkginfo);
@@ -195,23 +196,23 @@ Generator.prototype.generate = function(options) {
             }
         })
         .then(function() {
-            const deps = templates[tmplName].deps || [];
+            const deps = templateList[tmplName].deps || [];
             return promise.all(deps.map(function(dep) {
-                if (!templates[dep]) {
+                if (!templateList[dep]) {
                     log.warn("generator#generate()", "Invalid template id:" + dep);
                     return;
-                } else if (!templates[dep].path) {
+                } else if (!templateList[dep].path) {
                     log.warn("generator#generate()", "Invalid template path:" + dep);
                     return;
                 }
-                return copyToDirAsync(templates[dep].path, dest);
+                return copyToDirAsync(templateList[dep].path, dest);
             }));
         })
         .then(function() {
             log.info("generator#generate()", "done");
-            return {
+            return next(null, {
                 msg: "Success"
-            };
+            });
         })
         .catch(function(err) {
             log.silly("generator#generate()", "err:", err);
@@ -235,11 +236,11 @@ Generator.prototype.generate = function(options) {
                     fs.writeFileSync(destFile, qmlFile, {encoding: 'utf8'});
                 });
         }))
-        .then( function() {
+        .then(function() {
             log.info("generator#generate()#_writeAppIDdata()", "done");
             return;
         })
-        .catch( function(err) {
+        .catch(function(err) {
             log.silly("generator#generate()#_writeAppIDdata()", "err:", err);
             throw err;
         });
@@ -257,17 +258,17 @@ Generator.prototype.generate = function(options) {
                     // eslint-disable-next-line no-useless-escape
                     const exp = new RegExp("(?:[\'\"])([\:/.A-z?<_&\s=>0-9;-]+\')");
                     // eslint-disable-next-line no-useless-escape
-                    html=html.replace(exp, "\'"+url+"\'");
+                    html=html.replace(exp, "\'" + url + "\'");
                     const destFile = path.join(dest, path.basename(file));
 
                     fs.writeFileSync(destFile, html, {encoding: 'utf8'});
                 });
         }))
-        .then( function() {
+        .then(function() {
             log.info("generator#generate()#_writeURLdata()", "done");
             return;
         })
-        .catch( function(err) {
+        .catch(function(err) {
             log.silly("generator#generate()#_writeURLdata()", "err:", err);
             throw err;
         });
@@ -310,15 +311,64 @@ Generator.prototype.generate = function(options) {
                         });
                 });
         }))
-        .then( function() {
+        .then(function() {
             log.info("generator#generate()#_writeMetadata()", "done");
             return;
         })
-        .catch( function(err) {
+        .catch(function(err) {
             log.silly("generator#generate()#_writeMetadata()", "err:", err);
             throw err;
         });
     }
 };
+
+Generator.prototype.getTmpl = function() {
+    return templates;
+};
+
+Generator.prototype.existOutDir = function(outDir) {
+    log.verbose("generator#existOutDir()", outDir);
+    try {
+        const files = fs.readdirSync(outDir);
+        if (files.length > 0)
+            return true;
+    } catch (err) {
+        if (err && err.code === 'ENOTDIR') {
+            throw errHndl.getErrMsg("NOT_DIRTYPE_PATH", outDir);
+        }
+        if (err && err.code === 'ENOENT') {
+            log.verbose("generator#generate()", "The directory does not exist.");
+            return false;
+        }
+        throw err;
+    }
+};
+
+// Internal functions
+function parsePropArgs(property, targetInfo) {
+    const props = property || [],
+        info = targetInfo || {};
+    if (props.length === 1 && props[0].indexOf('{') !== -1 && props[0].indexOf('}') !== -1 &&
+        ( (props[0].split("'").length - 1) % 2) === 0)
+    {
+        // eslint-disable-next-line no-useless-escape
+        props[0] = props[0].replace(/\'/g,'"');
+    }
+    props.forEach(function(prop) {
+        try {
+            const data = JSON.parse(prop);
+            for (const k in data) {
+                info[k] = data[k];
+            }
+        } catch (err) {
+            const tokens = prop.split('=');
+            if (tokens.length === 2) {
+                info[tokens[0]] = tokens[1];
+            } else {
+                log.warn('Ignoring invalid arguments:', prop);
+            }
+        }
+    });
+}
 
 module.exports = Generator;

--- a/spec/jsSpecs/ares-generate.spec.js
+++ b/spec/jsSpecs/ares-generate.spec.js
@@ -244,7 +244,7 @@ describe(aresCmd + ' --template', function() {
         });
     });
 
-    it('hosted_webapp : generate qml template app', function(done) {
+    it('hosted_webapp : generate hosted template app', function(done) {
         const url = "http://www.google.com";
         exec(cmd + ` -t hosted_webapp -p "url=${url}" ${sampleAppPath}`, function (error, stdout, stderr) {
             if (stderr && stderr.length > 0) {
@@ -259,7 +259,7 @@ describe(aresCmd + ' --template', function() {
                 console.error(err);
             }
 
-            expect(text).toContain(url);
+            expect(text.toString()).toContain(url);
             expect(error).toBeNull();
             done();
         });

--- a/spec/test_data/ares-generate.json
+++ b/spec/test_data/ares-generate.json
@@ -1,14 +1,16 @@
 {   
     "ose" : {
         "list" : [
-            "webapp         Web App          -  (default) web app for webOS",
-            "hosted_webapp  Web App          -  hosted web app for webOS",
-            "webappinfo     Web App Info     -  appinfo.json for web app",
-            "js_service     JS Service       -  js service for webOS",
-            "jsserviceinfo  JS Service Info  -  services.json, package.json for JS service",
-            "icon           Icon             -  app icon files [80x80]",
-            "qmlapp         QML App          -  QML app for webOS",
-            "qmlappinfo     QML App Info     -  appinfo.json for QML app"
+            "ID             Project Type     Description",
+            "-------------  ---------------  ------------------------------------------",
+            "webapp         Web App          (default) web app for webOS",
+            "hosted_webapp  Web App          hosted web app for webOS",
+            "webappinfo     Web App Info     appinfo.json for web app",
+            "js_service     JS Service       js service for webOS",
+            "jsserviceinfo  JS Service Info  services.json, package.json for JS service",
+            "icon           Icon             app icon files [80x80]",
+            "qmlapp         QML App          QML app for webOS",
+            "qmlappinfo     QML App Info     appinfo.json for QML app"
         ],
         "template" : {
             "webapp" : "webapp",


### PR DESCRIPTION
Release Notes:
Support ares-generate to APIs

:Detailed Notes:
- Show template list, generate templates as APIs
- Refactoring code to support CLI and APIs
- Remove unsing code

:Testing Performed:
1. Pass CLI unit test(list function test timeout)
2. Pass eslint(will be fixed)
3. Check each APIs are woking fine using test app

:Issues Addressed:
[WRO-10299] Develop APIs of ares-generate - phase2