### PR TITLE
Support ares-package to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,19 @@
+const {promisify} = require('util'),
+    aresLauncher = require('./lib/launch'),
+    AresGenerator = require('./lib/generator'),
+    aresPackager = require('./lib/package');
+
+const Launcher = {
+    launch: promisify(aresLauncher.launch),
+    close: promisify(aresLauncher.close),
+    listRunningApp: promisify(aresLauncher.listRunningApp)
+};
+
+const Generator = new AresGenerator();
+const Packager = new aresPackager.Packager();
+
+module.exports = {
+    Launcher,
+    Generator,
+    Packager
+};

--- a/bin/ares-package.js
+++ b/bin/ares-package.js
@@ -171,11 +171,12 @@ PalmPackage.prototype = {
         }
 
         if (Object.hasOwnProperty.call(this.argv, 'app-exclude')) {
-            for(const excl_file in this.argv) {
-                if ((this.argv[excl_file]).toString() === "appinfo.json") {
-                    this.finish(errHndl.getErrMsg("NOT_EXCLUDE_APPINFO"));
-                }
-            }
+            // for(const excl_file in this.argv) {
+                // console.log("Aaa"+this.argv[excl_file])
+                // if ((this.argv[excl_file]).toString() === "appinfo.json") {
+                //     this.finish(errHndl.getErrMsg("NOT_EXCLUDE_APPINFO"));
+                // }
+            // }
             this.options.excludefiles = this.argv['app-exclude'];
         }
 
@@ -192,24 +193,24 @@ PalmPackage.prototype = {
         }
 
         if (Object.hasOwnProperty.call(this.argv, 'sign')) {
-            if (!fs.existsSync(path.resolve(this.argv.sign))) {
-                this.finish(errHndl.getErrMsg("NOT_EXIST_PATH", this.argv.sign));
-            }
+            // if (!fs.existsSync(path.resolve(this.argv.sign))) {
+            //     return this.finish(errHndl.getErrMsg("NOT_EXIST_PATH", this.argv.sign));
+            // }
             this.options.sign = this.argv.sign;
         }
 
         if (Object.hasOwnProperty.call(this.argv, 'certificate')) {
-            if (!fs.existsSync(path.resolve(this.argv.certificate))) {
-                this.finish(errHndl.getErrMsg("NOT_EXIST_PATH", this.argv.certificate));
-            }
+            // if (!fs.existsSync(path.resolve(this.argv.certificate))) {
+            //     return this.finish(errHndl.getErrMsg("NOT_EXIST_PATH", this.argv.certificate));
+            // }
             this.options.certificate = this.argv.certificate;
         }
 
         // check sign option must be used with certificate option
-        if ((this.options.sign && !this.options.certificate) ||
-                (this.options.certificate && !this.options.sign)) {
-            this.finish(errHndl.getErrMsg("USE_WITH_OPTIONS", "sign, certificate"));
-        }
+        // if ((this.options.sign && !this.options.certificate) ||
+        //     (this.options.certificate && !this.options.sign)) {
+        //     this.finish(errHndl.getErrMsg("USE_WITH_OPTIONS", "sign, certificate"));
+        // }
 
         if (Object.hasOwnProperty.call(this.argv, 'pkgid')) {
             this.options.pkgid = this.argv.pkgid;
@@ -244,48 +245,47 @@ PalmPackage.prototype = {
         }
 
         // Check that the directorie exist
-        if (fs.existsSync(this.destination)) {
-            const stats = fs.statSync(this.destination);
-            if (!stats.isDirectory()) {
-                this.finish(errHndl.getErrMsg("NOT_DIRTYPE_PATH", this.destination));
-            }
-        } else {
-            log.verbose("setOutputDir()", "creating directory '" + this.destination + "' ...");
-            mkdirp.sync(this.destination);
-        }
-        this.destination = fs.realpathSync(this.destination);
+        // if (fs.existsSync(this.destination)) {
+        //     const stats = fs.statSync(this.destination);
+        //     if (!stats.isDirectory()) {
+        //         this.finish(errHndl.getErrMsg("NOT_DIRTYPE_PATH", this.destination));
+        //     }
+        // } else {
+        //     log.verbose("setOutputDir()", "creating directory '" + this.destination + "' ...");
+        //     mkdirp.sync(this.destination);
+        // }
+        // this.destination = fs.realpathSync(this.destination);
         next();
     },
 
     checkInputDir: function(next) {
         log.info("checkInputDir()");
-        const packager = new packageLib.Packager(this.options);
+        const packager = new packageLib.Packager();
         this.appCnt = packager.checkInputDirectories(this.argv.argv.remain, this.options, next);
     },
 
     packageApp: function(next) {
         log.info("packageApp()");
-        const packager = new packageLib.Packager(this.options);
+        const packager = new packageLib.Packager();
         if(this.appCnt === 0) { // only service packaging
-            if (Object.hasOwnProperty.call(this.options, 'pkginfofile') && Object.hasOwnProperty.call(this.options, 'pkgid')) {
-                this.finish(errHndl.getErrMsg("NOT_USE_WITH_OPTIONS", "pkginfofile, pkgid"));
-                cliControl.end(-1);
-            }
-            else if (Object.hasOwnProperty.call(this.options, 'pkgid')) {
-                packager.servicePackaging(this.argv.argv.remain, this.destination, this.options, next);
-            }
-            else if (Object.hasOwnProperty.call(this.options, 'pkginfofile')) {
-                packager.servicePackaging(this.argv.argv.remain, this.destination, this.options, next);
-            }
-            else {
-                this.finish(errHndl.getErrMsg("USE_PKGID_PKGINFO"));
-                cliControl.end(-1);
-            }
+            // if (Object.hasOwnProperty.call(this.options, 'pkginfofile') && Object.hasOwnProperty.call(this.options, 'pkgid')) {
+            //     return this.finish(errHndl.getErrMsg("NOT_USE_WITH_OPTIONS", "pkginfofile, pkgid"));
+            // }
+            // else if (Object.hasOwnProperty.call(this.options, 'pkgid')) {
+            //     packager.servicePackaging(this.argv.argv.remain, this.destination, this.options, this.outputTxt, next);
+            // }
+            // else if (Object.hasOwnProperty.call(this.options, 'pkginfofile')) {
+            //     packager.servicePackaging(this.argv.argv.remain, this.destination, this.options, this.outputTxt, next);
+            // }
+            // else {
+                packager.servicePackaging(this.argv.argv.remain, this.destination, this.options, this.outputTxt, next);
+                // return this.finish(errHndl.getErrMsg("USE_PKGID_PKGINFO"));
+            // }
         } else { // app+service packaging
-            if (Object.hasOwnProperty.call(this.options, 'pkgid') || Object.hasOwnProperty.call(this.options, 'pkgversion') || Object.hasOwnProperty.call(this.options, 'pkginfofile')) {
-                this.finish(errHndl.getErrMsg("NOT_USE_WITH_OPTIONS", "pkgid, pkgversion, pkginfofile"));
-            }
-            packager.generatePackage(this.argv.argv.remain, this.destination, this.options, next);
+            // if (Object.hasOwnProperty.call(this.options, 'pkgid') || Object.hasOwnProperty.call(this.options, 'pkgversion') || Object.hasOwnProperty.call(this.options, 'pkginfofile')) {
+            //     this.finish(errHndl.getErrMsg("NOT_USE_WITH_OPTIONS", "pkgid, pkgversion, pkginfofile"));
+            // }
+            packager.generatePackage(this.argv.argv.remain, this.destination, this.options, this.outputTxt, next);
         }
     },
 
@@ -312,7 +312,7 @@ PalmPackage.prototype = {
 
     showPkgInfo: function() {
         log.info("showPkgInfo()");
-        const packager = new packageLib.Packager(this.options);
+        const packager = new packageLib.Packager();
         packager.analyzeIPK(this.options, this.finish);
     },
 
@@ -340,6 +340,11 @@ PalmPackage.prototype = {
             }
             cliControl.end();
         }
+    },
+
+    outputTxt: function(value) {
+        log.info("outputTxt()");
+        console.log(value);
     },
 
     exec: function() {

--- a/lib/package.js
+++ b/lib/package.js
@@ -55,82 +55,110 @@ const ar = require('ar-async'),
         module.exports = packager;
     }
 
-    function Packager(options) {
+    function Packager() {
         this.objectId = objectCounter++;
         this.verbose = false;
         this.silent = true;
-
-        if (options && options.level) {
-            log.level = options.level;
-            if (['warn', 'error'].indexOf(options.level) !== -1) {
-                this.silent = false;
-            }
-        }
-
         this.noclean = false;
-        if (options && options.noclean === true) {
-            this.noclean = true;
-        }
-
         this.nativecmd = false;
-        if (options && options.nativecmd === true) {
-            this.nativecmd = true;
-        }
-
         this.minify = true;
-        if (options && Object.prototype.hasOwnProperty.call(options, 'minify')) {
-            this.minify = options.minify;
-        }
-
         this.excludeFiles = [];
-        if (options && Object.prototype.hasOwnProperty.call(options, 'excludefiles')) {
-            if (options.excludefiles instanceof Array) {
-                this.excludeFiles = options.excludefiles;
-            } else {
-                this.excludeFiles.push(options.excludefiles);
-            }
-        }
-
         this.rom = false;
-        if (options && Object.prototype.hasOwnProperty.call(options, 'rom')) {
-            this.rom = options.rom;
-        }
-
         this.encrypt = false;
-        if (options && Object.prototype.hasOwnProperty.call(options, 'encrypt')) {
-            this.encrypt = options.encrypt;
-        }
-
         this.sign = "";
-        if (options && Object.prototype.hasOwnProperty.call(options, 'sign')) {
-            this.sign = options.sign;
-        }
-
         this.certificate = "";
-        if (options && Object.prototype.hasOwnProperty.call(options, 'certificate')) {
-            this.certificate = options.certificate;
-        }
-
-        log.verbose("package#Packager()", "Packager id:" + this.objectId);
         this.appCount = 0;
         this.services = [];
         this.pkgServiceNames = [];
-        this.pkgVersion = options.pkgversion || "1.0.0";
-
-        if (options && Object.prototype.hasOwnProperty.call(options, 'pkgid')) {
-            this.pkgId = options.pkgid;
-        }
-
-        if (options && Object.prototype.hasOwnProperty.call(options, 'pkginfofile')) {
-            this.pkginfofile = options.pkginfofile;
-        }
+        this.pkgVersion = "1.0.0";
+        this.pkgId;
+        this.pkginfofile;
     }
 
     packager.Packager = Packager;
 
     Packager.prototype = {
+        prepareOptions: function(options, next) {
+            if (options && options.level) {
+                log.level = options.level;
+                if (['warn', 'error'].indexOf(options.level) !== -1) {
+                    this.silent = false;
+                }
+            }
+
+            if (options && options.noclean === true) {
+                this.noclean = true;
+            }
+
+            if (options && options.nativecmd === true) {
+                this.nativecmd = true;
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'minify')) {
+                this.minify = options.minify;
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'excludefiles')) {
+                if (options.excludefiles instanceof Array) {
+                    this.excludeFiles = options.excludefiles;
+                } else {
+                    this.excludeFiles.push(options.excludefiles);
+                }
+
+                this.excludeFiles.forEach(function(excl_file) {
+                    if (excl_file === "appinfo.json") {
+                        return next(errHndl.getErrMsg("NOT_EXCLUDE_APPINFO"));
+                    }
+                });
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'rom')) {
+                this.rom = options.rom;
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'encrypt')) {
+                this.encrypt = options.encrypt;
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'sign')) {
+                if (!fs.existsSync(path.resolve(options.sign))) {
+                    return next(errHndl.getErrMsg("NOT_EXIST_PATH", options.sign));
+                }
+                this.sign = options.sign;
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'certificate')) {
+                if (!fs.existsSync(path.resolve(options.certificate))) {
+                    return next(errHndl.getErrMsg("NOT_EXIST_PATH", options.certificate));
+                }
+                this.certificate = options.certificate;
+            }
+
+            // check sign option must be used with certificate option
+            if ((this.sign && !this.certificate) ||
+                (this.certificate && !this.sign)) {
+                return next(errHndl.getErrMsg("USE_WITH_OPTIONS", "sign, certificate"));
+            }
+
+            log.verbose("package#Packager()", "Packager id:" + this.objectId);
+
+            this.pkgVersion = options.pkgversion? options.pkgversion : "1.0.0";
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'pkgid')) {
+                this.pkgId = options.pkgid;
+            }
+
+            if (options && Object.prototype.hasOwnProperty.call(options, 'pkginfofile')) {
+                this.pkginfofile = options.pkginfofile;
+            }
+
+            if (this.pkgId && this.pkginfofile){
+                return next(errHndl.getErrMsg("NOT_USE_WITH_OPTIONS", "pkginfofile, pkgid"));
+            }
+        },
         checkInputDirectories: function(inDirs, options, next) {
             log.verbose("package#Packager#checkInputDirectories()", "input directory:", inDirs);
+            this.prepareOptions(options, next);
 
             async.forEachSeries(inDirs, checkDirectory.bind(this, options), function(err) {
                 if (err) {
@@ -141,8 +169,13 @@ const ar = require('ar-async'),
             });
             return this.appCount;
         },
-        servicePackaging: function(inDirs, destination, options, next) {
+        servicePackaging: function(inDirs, destination, options, middleCb, next) {
             log.info("package#Packager#servicePackaging()");
+
+            if (!Object.hasOwnProperty.call(options, 'pkgid') && !Object.hasOwnProperty.call(options, 'pkginfofile')) {
+                return next(errHndl.getErrMsg("USE_PKGID_PKGINFO"));
+            }
+
             async.series([
                 this.checkInputDirectories.bind(this, inDirs, options),
                 setUmask.bind(this, 0),
@@ -162,9 +195,9 @@ const ar = require('ar-async'),
                 excludeFromApp.bind(this),
                 outputPackage.bind(this, destination),
                 encryptPackage.bind(this),
-                copyOutputToDst.bind(this, destination),
+                copyOutputToDst.bind(this, destination, middleCb),
                 recoverUmask.bind(this),
-                cleanupTmpDir.bind(this)
+                cleanupTmpDir.bind(this, middleCb)
             ], function(err) {
                 if (err) {
                     // TODO: call cleanupTmpDir() before returning
@@ -175,11 +208,16 @@ const ar = require('ar-async'),
                 setImmediate(next, null, {ipk: this.ipk, msg: "Success"});
             }.bind(this));
         },
-        generatePackage: function(inDirs, destination, options, next) {
+        generatePackage: function(inDirs, destination, options, middleCb, next) {
             log.info("package#Packager#generatePackage()", "from ", inDirs);
             // check whether app or service directories are copied or not
             this.dataCopyCount = 0;
             this.minifyDone = !this.minify;
+
+            if (Object.hasOwnProperty.call(options, 'pkgid') || Object.hasOwnProperty.call(options, 'pkgversion') || Object.hasOwnProperty.call(options, 'pkginfofile')) {
+                return next(errHndl.getErrMsg("NOT_USE_WITH_OPTIONS", "pkgid, pkgversion, pkginfofile"));
+            }
+
             async.series([
                 this.checkInputDirectories.bind(this, inDirs, options),
                 setUmask.bind(this, 0),
@@ -206,9 +244,9 @@ const ar = require('ar-async'),
                 excludeFromApp.bind(this),
                 outputPackage.bind(this, destination),
                 encryptPackage.bind(this),
-                copyOutputToDst.bind(this, destination),
+                copyOutputToDst.bind(this, destination, middleCb),
                 recoverUmask.bind(this),
-                cleanupTmpDir.bind(this)
+                cleanupTmpDir.bind(this, middleCb)
             ], function(err) {
                 if (err) {
                     // TODO: call cleanupTmpDir() before returning
@@ -222,6 +260,7 @@ const ar = require('ar-async'),
         analyzeIPK: function(options, next) {
             log.info("package#Packager#analyzeIPK()");
             let ipkConfigFile, ipkFile, ipkConfig, tmpDirPath;
+            this.prepareOptions(options);
 
             async.series([
                 _setConfig,
@@ -1129,6 +1168,18 @@ const ar = require('ar-async'),
     function outputPackage(destination, next) {
         log.info("package#outputPackage()");
 
+        // Check that the directorie exist
+        if (fs.existsSync(destination)) {
+            const stats = fs.statSync(destination);
+            if (!stats.isDirectory()) {
+                return next(errHndl.getErrMsg("NOT_DIRTYPE_PATH", destination));
+            }
+        } else {
+            log.verbose("setOutputDir()", "creating directory '" + destination + "' ...");
+            mkdirp.sync(destination);
+        }
+        destination = fs.realpathSync(destination);
+
         if (this.rom) {
             copySrcToDst.call(this, path.join(this.tempDir, 'data'), destination, next);
         } else {
@@ -1409,9 +1460,9 @@ const ar = require('ar-async'),
         ipkStream.on('error', next);
     }
 
-    function cleanupTmpDir(next) {
+    function cleanupTmpDir(middleCb, next) {
         if (this.noclean) {
-            console.log("Skipping removal of  " + this.tempDir);
+            middleCb("Skipping removal of  " + this.tempDir);
             setImmediate(next);
         } else {
             rimraf(this.tempDir, function(err) {
@@ -1677,7 +1728,7 @@ const ar = require('ar-async'),
                     const rmDir = path.join(this.applicationDir, this.dirName);
                     shelljs.rm('-rf', rmDir);
                 } catch (err) {
-                    console.log("ERROR:" + err);
+                    next(Error("ERROR" + err), null);
                 }
             }
         }
@@ -1834,14 +1885,14 @@ const ar = require('ar-async'),
         setImmediate(next);
     }
 
-    function copyOutputToDst(destination, next) {
+    function copyOutputToDst(destination, middleCb, next) {
         // copy data directory to destination
         if (this.rom) {
-            console.log("Create output directory to " + destination);
+            middleCb("Create output directory to " + destination);
             copySrcToDst.call(this, path.join(this.tempDir, 'data'), destination, next);
         } else if (this.encrypt) {
             // copy encrypted ipk to destination
-            console.log("Create encrypted " + this.ipkFileName + " to " + destination);
+            middleCb("Create encrypted " + this.ipkFileName + " to " + destination);
             copySrcToDst.call(this, path.join(this.encryptDir, this.ipkFileName), destination, next);
         } else {
             // copy plain ipk to destination
@@ -1849,7 +1900,7 @@ const ar = require('ar-async'),
             if (this.sign && this.certificate) {
                 outmsg = outmsg.concat("signed ");
             }
-            console.log(outmsg + this.ipkFileName + " to " + destination);
+            middleCb(outmsg + this.ipkFileName + " to " + destination);
             copySrcToDst.call(this, path.join(this.tempDir, this.ipkFileName), destination, next);
         }
     }


### PR DESCRIPTION
:Release Notes:
Support ares-package to APIs

:Detailed Notes:
- Open generatePackage, servicePackaging, and analyzeIPK  functions as APIs

:Testing Performed:
- Passed CLI unit test on OSE target
- Check each APIs are woking fine using test app

:Issues Addressed:
[WRO-12083] Develop APIs of ares-package - phase2