### PR TITLE
Support ares-launch to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,12 @@
+const {promisify} = require('util'),
+    aresLauncher = require('./lib/launch');
+
+const Launcher = {
+    launch: promisify(aresLauncher.launch),
+    close: promisify(aresLauncher.close),
+    listRunningApp: promisify(aresLauncher.listRunningApp)
+};
+
+module.exports = {
+    Launcher
+};

--- a/bin/ares-launch.js
+++ b/bin/ares-launch.js
@@ -43,7 +43,6 @@ const knownOpts = {
     "running":  Boolean,
     "display" : [String, null],
     "params":   [String, Array],
-    "host-port": [String, null],
     "version":  Boolean,
     "help":     Boolean,
     "hidden-help":      Boolean,
@@ -59,7 +58,6 @@ const shortHands = {
     "r": ["--running"],
     "dp": ["--display"],
     "p": ["--params"],
-    "P": ["--host-port"],
     "V": ["--version"],
     "h": ["--help"],
     "hh": ["--hidden-help"],
@@ -96,7 +94,6 @@ const options = {
         inspect: argv.open || argv.inspect,
         open: argv.open,
         installMode: "Installed",
-        hostPort: argv["host-port"],
         display: argv.display
     },
     appId = argv.argv.remain[0];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@webosose/ares-cli",
   "version": "2.3.1",
   "description": "Command Line Interface for development webOS application and service",
-  "main": "./bin/ares.js",
+  "main": "APIs.js",
   "author": "ye.kim",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release Notes:
Support ares-launch to APIs

:Detailed Notes:
- Open launch, close and listRunningApp functions as APIs
- Remove unusing option

:Testing Performed:
1. Passed CLI unit test on OSE target
2. Pass eslint
3. Check each APIs are woking fine using test app

:Issues Addressed:
[WRO-7774] Develop APIs of ares-launch