### PR TITLE
Support ares-install to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,12 @@
+const {promisify} = require('util'),
+    aresInstaller = require('./lib/install');
+
+const Installer = {
+    install: promisify(aresInstaller.install),
+    remove: promisify(aresInstaller.remove),
+    list: promisify(aresInstaller.list)
+};
+
+module.exports = {
+    Installer
+};

--- a/bin/ares-install.js
+++ b/bin/ares-install.js
@@ -147,15 +147,15 @@ function install() {
         if (!fs.existsSync(path.normalize(pkgPath))) {
             return finish(errHndl.getErrMsg("NOT_EXIST_PATH", pkgPath));
         }
-        installLib.install(options, pkgPath, finish);
+        installLib.install(options, pkgPath, finish, outputTxt);
     }
 }
 
-function list(){
+function list() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
         if (Array.isArray(pkgs)) {
-            pkgs.forEach(function (pkg) {
+            pkgs.forEach(function(pkg) {
                 if (argv.type) {
                     if (argv.type !== pkg.type) {
                         return;
@@ -165,21 +165,21 @@ function list(){
             });
         }
         finish(err, {msg : strPkgs.trim()});
-    });
+    }, outputTxt);
 }
 
 function listFull() {
     installLib.list(options, function(err, pkgs) {
         let strPkgs = "";
         if (Array.isArray(pkgs)) {
-            pkgs.forEach(function (pkg) {
+            pkgs.forEach(function(pkg) {
                 strPkgs += "id : "+ pkg.id + '\n';
                 delete pkg.id;
                 strPkgs += convertJsonToList(pkg, 0) + '\n';
             });
         }
         finish(err, {msg : strPkgs.trim()});
-    });
+    }, outputTxt);
 }
 
 function remove() {
@@ -188,7 +188,12 @@ function remove() {
     if (!pkgId) {
         return finish(errHndl.getErrMsg("EMPTY_VALUE", "APP_ID"));
     }
-    installLib.remove(options, pkgId, finish);
+    installLib.remove(options, pkgId, finish, outputTxt);
+}
+
+function outputTxt(value) {
+    log.info("outputTxt()", "value:", value);
+    console.log(value);
 }
 
 function finish(err, value) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -38,7 +38,7 @@ const async = require('async'),
          * @param {String} hostPkgPath absolute path on the host of the package to be installed
          * @param {Function} next common-js callback
          */
-        install: function(options, hostPkgPath, next) {
+        install: function(options, hostPkgPath, next, middleCb) {
             if (typeof next !== 'function') {
                 throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
@@ -91,7 +91,7 @@ const async = require('async'),
                     options.session.run(cmd, null, null, null, next);
                 },
                 function(next) {
-                    console.log("Installing package " + hostPkgPath);
+                    middleCb("Installing package " + hostPkgPath);
                     spinner.start();
                     options.session.put(hostPkgPath, devicePkgPath, next);
                 },
@@ -197,7 +197,7 @@ const async = require('async'),
 
                         function __data(data) {
                             const str = (Buffer.isBuffer(data)) ? data.toString() : data;
-                            console.log(str.trim());
+                            middleCb(str.trim());
                         }
                     }
 
@@ -257,7 +257,7 @@ const async = require('async'),
             });
         },
 
-        remove: function(options, packageName, next) {
+        remove: function(options, packageName, next, middleCb) {
             if (typeof next !== 'function') {
                 throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
@@ -299,7 +299,7 @@ const async = require('async'),
                             if (str.match(/No packages installed or removed/g)) {
                                 return next(errHndl.getErrMsg("FAILED_REMOVE_PACKAGE", packageName));
                             } else {
-                                console.log(str.trim());
+                                middleCb(str.trim());
                             }
                         }
 
@@ -360,7 +360,7 @@ const async = require('async'),
             });
         },
 
-        list: function(options, next) {
+        list: function(options, next, middleCb) {
             if (typeof next !== 'function') {
                 throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
@@ -402,7 +402,7 @@ const async = require('async'),
 
                         function __data(data) {
                             const str = (Buffer.isBuffer(data)) ? data.toString() : data;
-                            console.log(str.trim());
+                            middleCb(str.trim());
                         }
                     }
 

--- a/lib/launch.js
+++ b/lib/launch.js
@@ -102,7 +102,9 @@ const async = require('async'),
                 if (options.installMode === "Hosted" && !hostedAppInstalled) {
                     const hostedAppUrl = path.join(__dirname,hostedAppId + ".ipk");
                     options.appId = id;
-                    installer.install(options, hostedAppUrl, next);
+                    installer.install(options, hostedAppUrl, next, function(value) {
+                        console.log(value);
+                    });
                 } else {
                     next();
                 }


### PR DESCRIPTION
Release Notes:
Support ares-install to APIs

:Detailed Notes:
Install, remove and list functions as APIs

:Testing Performed:
- Passed CLI unit test on OSE target
- Pass eslint
- Check each APIs are woking fine using test app

:Issues Addressed:
[WRO-13907] Develop APIs of ares-install-phase2