### PR TITLE
Support ares-shell to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,11 @@
+const {promisify} = require('util'),
+    aresShell = require('./lib/shell');
+
+const Shell = {
+    remoteRun: promisify(aresShell.remoteRun),
+    shell: promisify(aresShell.shell)
+};
+
+module.exports = {
+    Shell
+};

--- a/lib/shell.js
+++ b/lib/shell.js
@@ -51,10 +51,20 @@ const async = require('async'),
                     }
 
                     log.info("shell#remoteRun()", "cmd :", runCommand);
-                    options.session.run(runCommand, process.stdin, process.stdout, process.stderr, next);
+                    options.session.run(runCommand, process.stdin, _onData, _onErr, next);
+
+                    function _onData(data) {
+                        const str = (Buffer.isBuffer(data)) ? data.toString() : data;
+                        next(null, str.trim());
+                    }
+
+                    function _onErr(err) {
+                        next(errHndl.getErrMsg(err), null);
+                    }
+
                 }
-            ], function(err) {
-                setImmediate(next, err);
+            ], function(err, results) {
+                next(err, {msg:results[3]});
             });
         },
 
@@ -155,7 +165,8 @@ const async = require('async'),
                     _ssh(options.session, next);
                 }
             ], function(err) {
-                setImmediate(next, err);
+                // Print "Connection to IP closed." message as like ssh prompt
+                next(err, {msg:"Connection to " + options.session.target.host + " closed."});
             });
         }
     };


### PR DESCRIPTION
:Release Notes:
Support ares-shell to APIs

:Detailed Notes:
remoteRun and shell functions as APIs

:Testing Performed:
- Passed CLI unit test on OSE target
- Pass eslint
- Check each APIs are woking fine using test app

:Issues Addressed:
[WRP-846] Develop APIs of ares-shell