### PR TITLE
Support ares-server to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,12 @@
+const {promisify} = require('util'),
+aresServer = require('./lib/base/server');
+
+const Server = {
+    runServer: promisify(aresServer.runServer),
+    openBrowser: promisify(aresServer.openBrowser),
+    stop: promisify(aresServer.stop)
+};
+
+module.exports = {
+    Server
+};

--- a/bin/ares-server.js
+++ b/bin/ares-server.js
@@ -114,11 +114,9 @@ function runServer() {
     async.waterfall([
         serverLib.runServer.bind(serverLib, appPath, port, _reqHandler),
         function(serverInfo, next) {
-            let openUrl;
             if (serverInfo && serverInfo.port) {
-                serverUrl = 'http://localhost:' + serverInfo.port;
-                openUrl = serverUrl + '/ares_cli/ares.html';
-                console.log("Local server running on " + serverUrl);
+                serverUrl = serverInfo.url;
+                console.log(serverInfo.msg);
             }
             if (argv.open && serverInfo.port) {
                 async.series([
@@ -127,8 +125,8 @@ function runServer() {
                     if (err) {
                         return next(err);
                     }
-                    log.info("runServer()", "openUrl:", openUrl, ", browserPath :", browserPath[0]);
-                    serverLib.openBrowser(openUrl, browserPath[0]);
+                    log.info("runServer()", "serverInfo.openBrowserUrl:", serverInfo.openBrowserUrl, ", browserPath :", browserPath[0]);
+                    serverLib.openBrowser(serverInfo.openBrowserUrl, browserPath[0]);
                 });
             }
             next();

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -5,6 +5,7 @@
  */
 
 const bodyParser = require('body-parser'),
+    npmlog = require('npmlog'),
     spawn = require('child_process').spawn,
     Express = require('express'),
     fs = require('fs'),
@@ -12,13 +13,20 @@ const bodyParser = require('body-parser'),
     errHndl = require('./error-handler');
 
 (function () {
+    const log = npmlog;
+    log.heading = 'server';
+    log.level = 'warn';
+
     const platformOpen = {
         win32: [ "cmd" , '/c', 'start' ],
         darwin:[ "open" ],
         linux: [ "xdg-open" ]
     };
 
-    const server = {};
+    const server = {},
+        sockets = {};
+    let localServer,
+        nextSocketId = 0;
 
     /**
      * Run a local web server based on the path
@@ -26,7 +34,8 @@ const bodyParser = require('body-parser'),
      * @param {port} port number for web server. 0 means random port.
      * @param {Function} next a common-JS callback invoked when the DB is ready to use.
      */
-    server.runServer =  function(path, port, reqHandlerForIFrame, next) {
+    server.runServer = function(path, port, reqHandlerForIFrame, next) {
+        log.verbose("server#runServer()");
         if (typeof reqHandlerForIFrame === 'function' && !next) {
             next = reqHandlerForIFrame;
             reqHandlerForIFrame = null;
@@ -47,7 +56,7 @@ const bodyParser = require('body-parser'),
             });
         }
 
-        const localServer = http.createServer(app);
+        localServer = http.createServer(app);
         localServer.on('error', function(err) {
             return next(errHndl.getErrMsg(err));
         });
@@ -57,11 +66,19 @@ const bodyParser = require('body-parser'),
             }
             const localServerPort = localServer.address().port,
                 url = 'http://localhost:' + localServerPort;
+
             next(null, {
-                "msg":"Local server running on " + url,
                 "url": url,
-                "port": localServerPort
+                "port": localServerPort,
+                "openBrowserUrl": url + "/ares_cli/ares.html",
+                "msg":"Local server running on " + url
             });
+        });
+        localServer.on('connection', function(socket) {
+            // Add a newly connected socket
+            const socketId = nextSocketId++;
+            sockets[socketId] = socket;
+            log.verbose("Socket opened: ", socketId);
         });
     };
 
@@ -72,6 +89,7 @@ const bodyParser = require('body-parser'),
      * @param {Function} next a common-JS callback invoked when the DB is ready to use. (optional)
      */
     server.openBrowser = function(url, browserPath, next) {
+        log.verbose("server#openBrowser()");
         let info = platformOpen[process.platform];
         if (typeof browserPath === 'function') {
             next = browserPath;
@@ -92,6 +110,20 @@ const bodyParser = require('body-parser'),
         if (next) {
             next();
         }
+    };
+
+    server.stop = function(next) {
+        log.verbose("server#stop()");
+
+        for(const socketId in sockets) {
+            log.verbose("Socket destroyed: ", socketId);
+            sockets[socketId].destroy();
+        }
+
+        localServer.close(function() {
+            log.verbose("Local server close called");
+            next(null, {msg: "Local server is stopped"});
+        });
     };
 
     if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
:Release Notes:
Support ares-server to APIs

:Detailed Notes:
- runServer and openBrowser functions as APIs
- Add stop function and as API

:Testing Performed:
- Passed CLI unit test on OSE target
- Pass eslint
- Check each APIs are woking fine using test app

:Issues Addressed:
[WRP-2679] Develop APIs of ares-server