### PR TITLE
Support ares-inspect to APIs

### DIFF
--- a/APIs.js
+++ b/APIs.js
@@ -1,0 +1,11 @@
+const {promisify} = require('util'),
+    aresInspecter = require('./lib/inspect');
+
+const Inspecter = {
+    inspect: promisify(aresInspecter.inspect),
+    stop: promisify(aresInspecter.stop)
+};
+
+module.exports = {
+    Inspecter
+};

--- a/bin/ares-inspect.js
+++ b/bin/ares-inspect.js
@@ -138,13 +138,13 @@ function inspect(){
         return finish(errHndl.getErrMsg("INVALID_DISPLAY"));
     }
 
-    async.series([
-            inspectLib.inspect.bind(inspectLib, options, null),
-            function() {
-                // TODO: hold process to keep alive
-            }
-    ], function(err) {
-        finish(err);
+    async.waterfall([
+        inspectLib.inspect.bind(inspectLib, options),
+        function(inspectInfo) {
+            console.log(inspectInfo.msg);
+        }
+    ], function(err, results) {
+        finish(err, results);
     });
 }
 

--- a/lib/base/server.js
+++ b/lib/base/server.js
@@ -5,6 +5,7 @@
  */
 
 const bodyParser = require('body-parser'),
+    npmlog = require('npmlog'),
     spawn = require('child_process').spawn,
     Express = require('express'),
     fs = require('fs'),
@@ -12,13 +13,20 @@ const bodyParser = require('body-parser'),
     errHndl = require('./error-handler');
 
 (function () {
+    const log = npmlog;
+    log.heading = 'server';
+    log.level = 'warn';
+
     const platformOpen = {
         win32: [ "cmd" , '/c', 'start' ],
         darwin:[ "open" ],
         linux: [ "xdg-open" ]
     };
 
-    const server = {};
+    const server = {},
+        sockets = {};
+    let localServer,
+        nextSocketId = 0;
 
     /**
      * Run a local web server based on the path
@@ -26,7 +34,8 @@ const bodyParser = require('body-parser'),
      * @param {port} port number for web server. 0 means random port.
      * @param {Function} next a common-JS callback invoked when the DB is ready to use.
      */
-    server.runServer =  function(path, port, reqHandlerForIFrame, next) {
+    server.runServer = function(path, port, reqHandlerForIFrame, next) {
+        log.verbose("server#runServer()");
         if (typeof reqHandlerForIFrame === 'function' && !next) {
             next = reqHandlerForIFrame;
             reqHandlerForIFrame = null;
@@ -47,7 +56,7 @@ const bodyParser = require('body-parser'),
             });
         }
 
-        const localServer = http.createServer(app);
+        localServer = http.createServer(app);
         localServer.on('error', function(err) {
             return next(errHndl.getErrMsg(err));
         });
@@ -57,11 +66,19 @@ const bodyParser = require('body-parser'),
             }
             const localServerPort = localServer.address().port,
                 url = 'http://localhost:' + localServerPort;
+
             next(null, {
-                "msg":"Local server running on " + url,
                 "url": url,
-                "port": localServerPort
+                "port": localServerPort,
+                "openBrowserUrl": url + "/ares_cli/ares.html",
+                "msg":"Local server running on " + url
             });
+        });
+        localServer.on('connection', function(socket) {
+            // Add a newly connected socket
+            const socketId = nextSocketId++;
+            sockets[socketId] = socket;
+            log.verbose("Socket opened: ", socketId);
         });
     };
 
@@ -72,6 +89,7 @@ const bodyParser = require('body-parser'),
      * @param {Function} next a common-JS callback invoked when the DB is ready to use. (optional)
      */
     server.openBrowser = function(url, browserPath, next) {
+        log.verbose("server#openBrowser()");
         let info = platformOpen[process.platform];
         if (typeof browserPath === 'function') {
             next = browserPath;
@@ -92,6 +110,20 @@ const bodyParser = require('body-parser'),
         if (next) {
             next();
         }
+    };
+
+    server.stop = function(next) {
+        log.verbose("server#stop()");
+
+        for(const socketId in sockets) {
+            log.verbose("Socket destroyed: ", socketId);
+            sockets[socketId].destroy();
+        }
+
+        localServer.close(function() {
+            log.verbose("Local server close called");
+            next(null, {msg: "Local server is stopped"});
+        });
     };
 
     if (typeof module !== 'undefined' && module.exports) {

--- a/lib/inspect.js
+++ b/lib/inspect.js
@@ -36,7 +36,7 @@ let platformNodeVersion = "0";
          */
         log: log,
 
-        inspect: function(options, params, next) {
+        inspect: function(options, next) {
             if (typeof next !== 'function') {
                 throw errHndl.getErrMsg("MISSING_CALLBACK", "next", util.inspect(next));
             }
@@ -59,14 +59,12 @@ let platformNodeVersion = "0";
                 _runApp,
                 _runAppPortForwardServer,
                 _runAppInspector,
-                _runServicePortForwardServer,
-                function(next) {
-                    log.info("inspect#inspect()", "running...");
-                    setImmediate(next);
-                }
+                _runServicePortForwardServer
             ], function(err, results) {
                 log.silly("inspect#inspect()", "err:", err, ", results:", results);
-                setImmediate(next, err);
+                const returnObj = {session : options.session};
+                returnObj.msg = options.serviceId ? results[6] : "Application Debugging - " + results[5];
+                next(err, returnObj);
             });
 
             function _findSdkEnv(next) {
@@ -137,7 +135,7 @@ let platformNodeVersion = "0";
                 }
             }
 
-            function _findNewDebugPort(dbgPort, next) {
+            function __findNewDebugPort(dbgPort, next) {
                 const format = "netstat -ltn 2>/dev/null | grep :%s | wc -l",
                     cmdPortInUsed = util.format(format, dbgPort);
 
@@ -158,18 +156,18 @@ let platformNodeVersion = "0";
                     }
 
                     if (str === "0") {
-                        log.silly("inspect#inspect()#_findNewDebugPort()", "final dbgPort : " + dbgPort);
+                        log.silly("inspect#inspect()#__findNewDebugPort()", "final dbgPort : " + dbgPort);
                         next(null, dbgPort);
                     } else if (str === "1") {
                         dbgPort = Number(dbgPort) +1;
-                        _findNewDebugPort(dbgPort, next);
+                        __findNewDebugPort(dbgPort, next);
                     } else {
                         return next(errHndl.getErrMsg("FAILED_GET_PORT"));
                     }
                 }
             }
 
-            function _getNodeVersion(next){
+            function __getNodeVersion(next){
                 const format = "node -v";
                 let count = 0;
 
@@ -198,11 +196,12 @@ let platformNodeVersion = "0";
             }
 
             function _runServicePortForwardServer(next) {
+                let guideText = "";
                 const svcIds = Object.keys(options.svcDbgInfo).filter(function(id) {
                     return id !== 'undefined';
                 });
                 async.forEachSeries(svcIds, __eachServicePortForward, function(err) {
-                        next(err);
+                        next(err, guideText);
                     }
                 );
 
@@ -222,13 +221,11 @@ let platformNodeVersion = "0";
                     log.info("inspect#inspect()#_eachServicePortForward()", "sessionId:" + options.sessionId + ", default dbgPort : " + dbgPort);
                     const __printInspectGuide = function(svcId, next) {
                         if (options.open) {
-                            console.log("Cannot support \"--open option\" on platform node version 8 and later");
+                            guideText = "Cannot support \"--open option\" on platform node version 8 and later\n";
                         }
-
-                        const guideText = "To debug your service, set " + "\"localhost:" + options.session.getLocalPortByName(svcId) +
+                        guideText += "To debug your service, set " + "\"localhost:" + options.session.getLocalPortByName(svcId) +
                                             "\" on Node's Inspector Client(Chrome DevTools, Visual Studio Code, etc.).";
-                        console.log(guideText);
-                        next();
+                        next(null, guideText);
                     };
 
                     const __launchServiceInspector = function(svcId, next) {
@@ -246,7 +243,6 @@ let platformNodeVersion = "0";
 
                         request.get(nodeInsptUrl, function(error, response) {
                             if (!error && response.statusCode === 200) {
-                                console.log("nodeInsptUrl:", nodeInsptUrl);
                                 server.runServer(__dirname, 0, _reqHandler, _postAction);
                                 next();
                             }
@@ -267,9 +263,9 @@ let platformNodeVersion = "0";
                                 if (err) {
                                     process.exit(1);
                                 } else if (serverInfo && serverInfo.msg && options.open) {
-                                        const serverUrl = 'http://localhost:' + serverInfo.port + '/ares_cli/ares.html';
-                                        server.openBrowser(serverUrl, options.bundledBrowserPath);
+                                    server.openBrowser(serverInfo.openBrowserUrl, options.bundledBrowserPath);
                                 }
+                                next(null, nodeInsptUrl);
                             }
                         });
                     };
@@ -341,7 +337,7 @@ let platformNodeVersion = "0";
                             const cmdMkDir = "mkdir -p " + options.svcDbgInfo[serviceId].path + "/_ares";
                             options.session.runNoHangup(cmdMkDir, next);
                         },
-                        _findNewDebugPort.bind(this, dbgPort),
+                        __findNewDebugPort.bind(this, dbgPort),
                         function makeDbgFile(port, next) {
                             dbgPort = port;
                             const cmdWriteDbgPort = "echo " + dbgPort + " > " + options.svcDbgInfo[serviceId].path + "/_ares/debugger-port";
@@ -371,7 +367,7 @@ let platformNodeVersion = "0";
                                 next();
                             },1000);
                         },
-                        _getNodeVersion.bind(this),
+                        __getNodeVersion.bind(this),
                         function doPortForward(next){
                             log.info("inspect#inspect()#_doPortForward()", "platformNodeVersion: "+ platformNodeVersion + ", nodeBaseVersion: " + nodeBaseVersion);
                             if (platformNodeVersion < nodeBaseVersion) {
@@ -452,9 +448,9 @@ let platformNodeVersion = "0";
                     if (err) {
                         process.exit(1);
                     } else if (serverInfo && serverInfo.msg && options.open) {
-                            const serverUrl = 'http://localhost:' + serverInfo.port + '/ares_cli/ares.html';
-                            server.openBrowser(serverUrl, options.bundledBrowserPath);
+                        server.openBrowser(serverInfo.openBrowserUrl, options.bundledBrowserPath);
                     }
+                    next(null, url);
                 }
 
                 if (options.appId) {
@@ -474,13 +470,19 @@ let platformNodeVersion = "0";
                             if (err) {
                                 return next(err);
                             }
-                            console.log("Application Debugging - " + url);
                             server.runServer(__dirname, 0, _reqHandler, _postAction);
                         }
                     );
+                } else {
+                    next();
                 }
-                next();
             }
+        },
+
+        stop: function(session, next) {
+            log.verbose("inspect#stop()", "session:", session);
+            session.end();
+            next(null, {msg : "This inspection has stopped"});
         }
     };
 


### PR DESCRIPTION
:Release Notes:
Support ares-inspect to APIs

:Detailed Notes:
- inspect functions as APIs
- Add stop function and as API

:Testing Performed:
- Passed CLI unit test on OSE target
- Pass eslint
- Check each APIs are woking fine using test app

:Issues Addressed:
[WRP-2689] Develop APIs of ares-inspect