### PR TITLE
Update version 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.4.0 (February 16, 2023)
+### ares-device
+* Supports to show node version usage using `--system-info` option.
+* Fixed a bug that js service is not listed-up when ares-device `--resource-monitor --list` option.
+
+### ares-inspect
+* Updated displayed guide text during js service inspection using `--service` option.
+
+### Common
+* Supports features of below commands as APIs(total 10s)
+: ares-generate, ares-inspect, ares-install, ares-launch, ares-package, ares-pull, ares-push, ares-server, ares-setup-device, ares-shell
+* Added unit test to verify APIs
+
+
 ## 2.3.0 (February 7, 2022)
 ### ares-log
 * Supports to show logs of pmlogd and added options to support related features.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webosose/ares-cli",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Command Line Interface for development webOS application and service",
   "main": "APIs.js",
   "author": "ye.kim",


### PR DESCRIPTION
:Release Notes:
Update version 2.4.0

:Detailed Notes:
- Update version in package.json and npm-shrinkwrap.json
- Update CHANGELOG.md

:Testing Performed:
1. Install CLI 2.4.0 package using below command
  $ sudo npm uninstall -g @webosose/ares-cli
  $ sudo npm install -g https://github.com:webosose/ares-cli.git#Update_version_2.4.0
3. Check version using below command 
  $ ares -V
  > Version: 2.4.0

:Issues Addressed:
[WRP-8976] Prepare to release CLI v2.4.0