### PR TITLE
setup-device: allow localhost

### DIFF
--- a/lib/base/setup-device.js
+++ b/lib/base/setup-device.js
@@ -190,7 +190,7 @@ const async = require('async'),
             if (!isValidDeviceName(inDevice.name)) {
                 return next(errHndl.getErrMsg("INVALID_DEVICENAME"));
             }
-            if (inDevice.host && !isValidIpv4(inDevice.host)) {
+            if (inDevice.host && inDevice.host !== "localhost" && !isValidIpv4(inDevice.host)) {
                 return next(errHndl.getErrMsg("INVALID_VALUE", "host", inDevice.host));
             }
             if (inDevice.port && !isValidPort(inDevice.port)) {


### PR DESCRIPTION
WSL based devices appear to need localhost as the host name to be able to connect via ssh.  127.0.0.1 does not work, and using a static IP is probably not the best of options, as the WSL instance IP could change every boot.

update: tested, with WSL based installation, am able to use localhost with ares tools after this change, and the tools operate
